### PR TITLE
REDO: reverted change to read_file, added portable format specifier for uint64_t, and added debug formatting to outputs

### DIFF
--- a/tests.c
+++ b/tests.c
@@ -977,13 +977,6 @@ static size_t read_file(const char *path, uint8_t *bytes) {
 		exit(EXIT_FAILURE);
 	}
 
-	// This part was originally in get_expected error 
-	// all calls to this function except for two in diff_roundtrip
-	// 
-	// This snippet was also needed for the two calls in diff_roundtrip
-	// so I moved it in here. 
-	//
-	// This can be 
 	if (bytes[len - 1] == '\n') {
 		len--;
 		if (bytes[len - 1] == '\r') {


### PR DESCRIPTION
- fopen in read_file now opens the file as "r" instead of "rb".
This is to prevent issues with grug implementations having to emit CRLF newlines on windows otherwise.

- added ifdef based portable format specifier for uint64_t. The usual way of doing this is with the inttypes header, but it was causing a wierd issue with %zu no longer being recognized. Right now, the only portable format specifier needed is PRIu64 so an ifdef based specifier is not hard to manage.
If more format specifiers are needed, we can try to get inttypes.h working again

- expected and actual output is now output in debug format, where whitespace is escaped to easily diff the outputs
- moved newline trimming from get_expected_error to read_file