### PR TITLE
fixed some test functions that did not pass arguments to on functions with arguments

### DIFF
--- a/tests.c
+++ b/tests.c
@@ -1849,13 +1849,13 @@ static void ok_helper_fn_returning_void_returns_void(void) {
 
 static void ok_helper_fn_same_param_name_as_on_fn(void) {
 	assert_call_count(nothing, 0);
-    on_fn_dispatcher("on_a");
+    on_fn_args_dispatcher("on_a", (const union grug_value[]){{._number=42.0}});
 	assert_call_count(nothing, 1);
 }
 
 static void ok_helper_fn_same_param_name_as_other_helper_fn(void) {
 	assert_call_count(nothing, 0);
-    on_fn_dispatcher("on_a");
+    on_fn_args_dispatcher("on_a", (const union grug_value[]){{._number=42.0}});
 	assert_call_count(nothing, 2);
 }
 


### PR DESCRIPTION
`ok_helper_fn_same_param_name_as_on_fn` and `ok_helper_fn_same_param_name_as_other_helper_fn` are supposed to call on_fn_args_dispatch with a single number argument but they call `on_fn_dispatcher` with no arguments. 

This should have resulted in a null pointer dereference in both c and python, but they didn't. I'm not sure why that is. 