### PR TITLE
Require bindings to pass `grug_state` create and destroy callbacks

### DIFF
--- a/smoketest.c
+++ b/smoketest.c
@@ -26,7 +26,7 @@ typedef HMODULE DllLib;
 static void (*p_grug_tests_run)(
     const char *,
 	const char *,
-	init_grug_state_t,
+	create_grug_state_t,
 	destroy_grug_state_t,
     compile_grug_file_t,
     init_globals_fn_dispatcher_t,
@@ -780,7 +780,7 @@ static void load_tests_so(void) {
     #pragma GCC diagnostic pop
 }
 
-static void* init_grug_state(const char* mod_api_dir, const char* mods_dir) {
+static void* create_grug_state(const char* mod_api_dir, const char* mods_dir) {
 	(void)(mod_api_dir);
 	(void)(mods_dir);
 	return (void*)(0);
@@ -804,7 +804,7 @@ int main(int argc, const char *argv[]) {
     p_grug_tests_run(
         "tests",
 		"mod_api.json",
-		init_grug_state,
+		create_grug_state,
 		destroy_grug_state,
         compile_grug_file,
         init_globals_fn_dispatcher,

--- a/tests.c
+++ b/tests.c
@@ -121,7 +121,7 @@ static const char *get_type_name[] = {
 
 static const char *tests_dir_path;
 static const char *mod_api_path;
-static init_grug_state_t init_grug_state;
+static create_grug_state_t create_grug_state;
 static destroy_grug_state_t destroy_grug_state;
 static compile_grug_file_t compile_grug_file;
 static init_globals_fn_dispatcher_t init_globals_fn_dispatcher;
@@ -3539,7 +3539,7 @@ static void add_runtime_error_tests(void) {
 void grug_tests_run(
 	const char *tests_dir_path_, 
 	const char *mod_api_path_, 
-	init_grug_state_t init_grug_state_,
+	create_grug_state_t create_grug_state_,
 	destroy_grug_state_t destroy_grug_state_,
 	compile_grug_file_t compile_grug_file_, 
 	init_globals_fn_dispatcher_t init_globals_fn_dispatcher_, 
@@ -3549,7 +3549,7 @@ void grug_tests_run(
 	game_fn_error_t game_fn_error_, 
 	const char *whitelisted_test_
 ) {
-	init_grug_state = init_grug_state_,
+	create_grug_state = create_grug_state_,
 	destroy_grug_state = destroy_grug_state_,
 	tests_dir_path = tests_dir_path_;
 	mod_api_path = mod_api_path_;
@@ -3562,7 +3562,7 @@ void grug_tests_run(
 	whitelisted_test = whitelisted_test_;
 
 	// We only have a single grug_state for now
-	void* grug_state = init_grug_state(
+	void* grug_state = create_grug_state(
 		mod_api_path,
 		tests_dir_path
 	);

--- a/tests.h
+++ b/tests.h
@@ -123,15 +123,15 @@ typedef void (*game_fn_error_t)(void* state, const char *message);
  * Initializes a grug_state and returns a pointer to it.
  * this state will be passed to game functions
  */
-typedef void* (*init_grug_state_t) (
+typedef void* (*create_grug_state_t) (
 	const char* mod_api_dir,
 	const char* mods_dir
 );
 
 /**
  * Destroys an exiting grug_state. The pointer passed to this function will be
- * a pointer returned from a previous call to `init_grug_state`. 
- * Note that the order that init_grug_state is called may not match the order
+ * a pointer returned from a previous call to `create_grug_state`. 
+ * Note that the order that create_grug_state is called may not match the order
  * that destroy_grug_state is called
  */
 typedef void (*destroy_grug_state_t)(void* grug_state);
@@ -156,7 +156,7 @@ typedef void (*destroy_grug_state_t)(void* grug_state);
  */
 void grug_tests_run(const char *tests_dir_path,
 					const char *mod_api_path,
-					init_grug_state_t init_grug_state,
+					create_grug_state_t create_grug_state,
 					destroy_grug_state_t destroy_grug_state,
                     compile_grug_file_t compile_grug_file,
                     init_globals_fn_dispatcher_t init_globals_fn_dispatcher,


### PR DESCRIPTION
Original Issue: #36 

Added two new functions to be defined by the testee.
- `init_grug_state`: Creates a new grug_state and returns a pointer to it
- `destroy_grug_state`: Destroys a previously created grug_state

All other callbacks and game functions now take a void* as the first argument which is a pointer returned from `init_grug_state`.

grug_tests_run now has an extra `mod_api_path` parameter in addition to the `tests_dir_path` parameter. This is passed to `init_grug_state` as initialization data. This is to support a future extension to tests.c which to test multiple mod_api.json.

Python cannot return a pointer through ctypes. There are two ways to allow grug-for-python to continue using tests.c. 
The first is to just continue using a global variable and return null from `init_grug_state`. 
The second option is to return a pointer sized integer, which would be an index into a global array of `grug_state`s. This would allow multiple grug_states to exist at the same time.

The reason both of these approaches can work is because tests.c treats the returned pointer as an opaque pointer.