### PR TITLE
Replaced '/' in paths with `SLASH` macro where the path is OS dependent

### DIFF
--- a/smoketest.c
+++ b/smoketest.c
@@ -91,8 +91,6 @@ static bool starts_with(const char *haystack, const char *needle) {
 static struct grug_file_id *compile_grug_file(struct grug_state* grug_state, const char *grug_file_path, const char** out_error) {
 	(void)(grug_state);
 
-	printf("file_path: %s\n", grug_file_path);
-	fflush(stdout);
     if (starts_with(grug_file_path, "err"SLASH)) {
         // Turn "err/foo-D.grug" into "err/expected_error.txt"
         const char *last_slash = strrchr(grug_file_path, *SLASH);
@@ -103,7 +101,7 @@ static struct grug_file_id *compile_grug_file(struct grug_state* grug_state, con
         expected_relative_path[dir_len] = '\0';
         strcat(expected_relative_path, "expected_error.txt");
 
-        char expected_path[4096] = "tests"SLASH;
+        char expected_path[4096] = "tests/";
         strcat(expected_path, expected_relative_path);
         FILE *f = fopen(expected_path, "r");
         assert(f);
@@ -549,7 +547,7 @@ static void call_export_fn(struct grug_state* grug_state, struct grug_file_id* f
     } else if (starts_with(grug_file_path, "ok"SLASH"pass_string_argument_to_helper_fn"SLASH)) {
         CALL(grug_state, say, grug_string("foo"));
     } else if (starts_with(grug_file_path, "ok"SLASH"resource_and_entity"SLASH)) {
-        CALL(grug_state, draw, grug_string("ok"SLASH"resource_and_entity"SLASH"foo.txt"));
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_and_entity/foo.txt"));
         CALL(grug_state, spawn, grug_string("ok:foo"));
     } else if (starts_with(grug_file_path, "ok"SLASH"resource_can_contain_dot_1"SLASH)) {
         CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_1/.foo"));
@@ -564,10 +562,10 @@ static void call_export_fn(struct grug_state* grug_state, struct grug_file_id* f
     } else if (starts_with(grug_file_path, "ok"SLASH"resource_can_contain_dot_dot_3"SLASH)) {
         CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_dot_3/foo..bar"));
     } else if (starts_with(grug_file_path, "ok"SLASH"resource_duplicate"SLASH)) {
-        CALL(grug_state, draw, grug_string("ok"SLASH"resource_duplicate"SLASH"foo.txt"));
-        CALL(grug_state, draw, grug_string("ok"SLASH"resource_duplicate"SLASH"bar.txt"));
-        CALL(grug_state, draw, grug_string("ok"SLASH"resource_duplicate"SLASH"bar.txt"));
-        CALL(grug_state, draw, grug_string("ok"SLASH"resource_duplicate"SLASH"baz.txt"));
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_duplicate/foo.txt"));
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_duplicate/bar.txt"));
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_duplicate/bar.txt"));
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_duplicate/baz.txt"));
     } else if (starts_with(grug_file_path, "ok"SLASH"return"SLASH)) {
         CALL(grug_state, initialize, grug_number(42.0));
     } else if (starts_with(grug_file_path, "ok"SLASH"return_from_on_fn"SLASH)) {

--- a/smoketest.c
+++ b/smoketest.c
@@ -299,7 +299,7 @@ static void call_export_fn(struct grug_state* grug_state, struct grug_file_id* f
     } else if (starts_with(grug_file_path, "ok"SLASH"entity_and_resource_as_subexpression"SLASH)) {
         CALL(grug_state, initialize_bool,
             grug_bool(
-                CALL(grug_state, has_resource, grug_string("ok"SLASH"entity_and_resource_as_subexpression"SLASH"foo.txt"))._bool
+                CALL(grug_state, has_resource, grug_string("ok"SLASH"entity_and_resource_as_subexpression/foo.txt"))._bool
                 && CALL(grug_state, has_string, grug_string("bar"))._bool
                 && CALL(grug_state, has_entity, grug_string("ok:baz"))._bool
             )
@@ -552,17 +552,17 @@ static void call_export_fn(struct grug_state* grug_state, struct grug_file_id* f
         CALL(grug_state, draw, grug_string("ok"SLASH"resource_and_entity"SLASH"foo.txt"));
         CALL(grug_state, spawn, grug_string("ok:foo"));
     } else if (starts_with(grug_file_path, "ok"SLASH"resource_can_contain_dot_1"SLASH)) {
-        CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_1"SLASH".foo"));
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_1/.foo"));
     } else if (starts_with(grug_file_path, "ok"SLASH"resource_can_contain_dot_2"SLASH)) {
-        CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_2"SLASH"foo."));
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_2/foo."));
     } else if (starts_with(grug_file_path, "ok"SLASH"resource_can_contain_dot_3"SLASH)) {
-        CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_3"SLASH"foo.bar"));
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_3/foo.bar"));
     } else if (starts_with(grug_file_path, "ok"SLASH"resource_can_contain_dot_dot_1"SLASH)) {
-        CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_dot_1"SLASH"..foo"));
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_dot_1/..foo"));
     } else if (starts_with(grug_file_path, "ok"SLASH"resource_can_contain_dot_dot_2"SLASH)) {
-        CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_dot_2"SLASH"foo.."));
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_dot_2/foo.."));
     } else if (starts_with(grug_file_path, "ok"SLASH"resource_can_contain_dot_dot_3"SLASH)) {
-        CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_dot_3"SLASH"foo..bar"));
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_dot_3/foo..bar"));
     } else if (starts_with(grug_file_path, "ok"SLASH"resource_duplicate"SLASH)) {
         CALL(grug_state, draw, grug_string("ok"SLASH"resource_duplicate"SLASH"foo.txt"));
         CALL(grug_state, draw, grug_string("ok"SLASH"resource_duplicate"SLASH"bar.txt"));

--- a/smoketest.c
+++ b/smoketest.c
@@ -12,6 +12,7 @@
 typedef void* DllLib;
 #define load_library(name) dlopen(name, RTLD_NOW | RTLD_LOCAL)
 #define load_symbol(lib, name) dlsym(lib, name)
+#define SLASH "/"
 
 #elif defined(WIN32) 
 
@@ -20,6 +21,7 @@ typedef void* DllLib;
 typedef HMODULE DllLib;
 #define load_library(name) LoadLibrary(name)
 #define load_symbol(lib, name) (void*)GetProcAddress(lib, name);
+#define SLASH "\\"
 
 #endif
 
@@ -89,9 +91,11 @@ static bool starts_with(const char *haystack, const char *needle) {
 static struct grug_file_id *compile_grug_file(struct grug_state* grug_state, const char *grug_file_path, const char** out_error) {
 	(void)(grug_state);
 
-    if (starts_with(grug_file_path, "err/")) {
+	printf("file_path: %s\n", grug_file_path);
+	fflush(stdout);
+    if (starts_with(grug_file_path, "err"SLASH)) {
         // Turn "err/foo-D.grug" into "err/expected_error.txt"
-        const char *last_slash = strrchr(grug_file_path, '/');
+        const char *last_slash = strrchr(grug_file_path, *SLASH);
         assert(last_slash);
         char expected_relative_path[4096];
         size_t dir_len = (size_t)(last_slash - grug_file_path + 1);
@@ -99,7 +103,7 @@ static struct grug_file_id *compile_grug_file(struct grug_state* grug_state, con
         expected_relative_path[dir_len] = '\0';
         strcat(expected_relative_path, "expected_error.txt");
 
-        char expected_path[4096] = "tests/";
+        char expected_path[4096] = "tests"SLASH;
         strcat(expected_path, expected_relative_path);
         FILE *f = fopen(expected_path, "r");
         assert(f);
@@ -124,19 +128,19 @@ static struct grug_file_id *compile_grug_file(struct grug_state* grug_state, con
 static void init_globals(struct grug_state* grug_state, struct grug_file_id* file_id) {
     const char *grug_file_path = (const char*)file_id;
 
-    if (starts_with(grug_file_path, "ok/custom_id_transfer_between_globals/")) {
+    if (starts_with(grug_file_path, "ok"SLASH"custom_id_transfer_between_globals"SLASH)) {
         CALL_ARGLESS(grug_state, get_opponent);
-    } else if (starts_with(grug_file_path, "ok/custom_id_with_digits/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"custom_id_with_digits"SLASH)) {
         CALL(grug_state, box_number, grug_number(42.0));
-    } else if (starts_with(grug_file_path, "ok/global_call_using_me/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"global_call_using_me"SLASH)) {
         CALL(grug_state, get_position, grug_id(42));
-    } else if (starts_with(grug_file_path, "ok/global_id/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"global_id"SLASH)) {
         CALL_ARGLESS(grug_state, get_opponent);
-    } else if (starts_with(grug_file_path, "ok/id_global_with_id_to_new_id/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"id_global_with_id_to_new_id"SLASH)) {
         CALL_ARGLESS(grug_state, retrieve);
-    } else if (starts_with(grug_file_path, "ok/id_global_with_opponent_to_new_id/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"id_global_with_opponent_to_new_id"SLASH)) {
         CALL_ARGLESS(grug_state, get_opponent);
-    } else if (starts_with(grug_file_path, "ok/string_returned_by_game_fn_assigned_to_member/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"string_returned_by_game_fn_assigned_to_member"SLASH)) {
         CALL_ARGLESS(grug_state, get_os);
     }
 }
@@ -148,23 +152,23 @@ static void call_export_fn(struct grug_state* grug_state, struct grug_file_id* f
 
     const char *grug_file_path = (const char*)file_id;
 
-    if (starts_with(grug_file_path, "err_runtime/all/")) {
+    if (starts_with(grug_file_path, "err_runtime"SLASH"all"SLASH)) {
         p_grug_tests_runtime_error_handler("Stack overflow, so check for accidental infinite recursion", GRUG_ON_FN_STACK_OVERFLOW, on_fn_name, grug_file_path);
-    } else if (starts_with(grug_file_path, "err_runtime/game_fn_error/")) {
+    } else if (starts_with(grug_file_path, "err_runtime"SLASH"game_fn_error"SLASH)) {
         CALL_ARGLESS(grug_state, cause_game_fn_error);
-    } else if (starts_with(grug_file_path, "err_runtime/game_fn_error_once/")) {
+    } else if (starts_with(grug_file_path, "err_runtime"SLASH"game_fn_error_once"SLASH)) {
         if (streq(on_fn_name, "on_a")) {
             CALL_ARGLESS(grug_state, cause_game_fn_error);
         } else {
             CALL_ARGLESS(grug_state, nothing);
         }
-    } else if (starts_with(grug_file_path, "err_runtime/on_fn_calls_erroring_on_fn/")) {
+    } else if (starts_with(grug_file_path, "err_runtime"SLASH"on_fn_calls_erroring_on_fn"SLASH)) {
         if (streq(on_fn_name, "on_a")) {
             CALL_ARGLESS(grug_state, call_on_b_fn);
         } else {
             CALL_ARGLESS(grug_state, cause_game_fn_error);
         }
-    } else if (starts_with(grug_file_path, "err_runtime/on_fn_errors_after_it_calls_other_on_fn/")) {
+    } else if (starts_with(grug_file_path, "err_runtime"SLASH"on_fn_errors_after_it_calls_other_on_fn"SLASH)) {
         if (streq(on_fn_name, "on_a")) {
 			const char* current_on_fn_name = on_fn_name;
             CALL_ARGLESS(grug_state, call_on_b_fn);
@@ -173,481 +177,481 @@ static void call_export_fn(struct grug_state* grug_state, struct grug_file_id* f
         } else {
             CALL_ARGLESS(grug_state, nothing);
         }
-    } else if (starts_with(grug_file_path, "err_runtime/stack_overflow/")) {
+    } else if (starts_with(grug_file_path, "err_runtime"SLASH"stack_overflow"SLASH)) {
         p_grug_tests_runtime_error_handler("Stack overflow, so check for accidental infinite recursion", GRUG_ON_FN_STACK_OVERFLOW, on_fn_name, grug_file_path);
-    } else if (starts_with(grug_file_path, "err_runtime/time_limit_exceeded/")) {
+    } else if (starts_with(grug_file_path, "err_runtime"SLASH"time_limit_exceeded"SLASH)) {
         p_grug_tests_runtime_error_handler("Took longer than 100 milliseconds to run", GRUG_ON_FN_TIME_LIMIT_EXCEEDED, on_fn_name, grug_file_path);
-    } else if (starts_with(grug_file_path, "err_runtime/time_limit_exceeded_exponential_calls/")) {
+    } else if (starts_with(grug_file_path, "err_runtime"SLASH"time_limit_exceeded_exponential_calls"SLASH)) {
         p_grug_tests_runtime_error_handler("Took longer than 100 milliseconds to run", GRUG_ON_FN_TIME_LIMIT_EXCEEDED, on_fn_name, grug_file_path);
-    } else if (starts_with(grug_file_path, "err_runtime/time_limit_exceeded_fibonacci/")) {
+    } else if (starts_with(grug_file_path, "err_runtime"SLASH"time_limit_exceeded_fibonacci"SLASH)) {
         p_grug_tests_runtime_error_handler("Took longer than 100 milliseconds to run", GRUG_ON_FN_TIME_LIMIT_EXCEEDED, on_fn_name, grug_file_path);
-    } else if (starts_with(grug_file_path, "ok/addition_as_argument/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"addition_as_argument"SLASH)) {
         CALL(grug_state, initialize, grug_number(3.0));
-    } else if (starts_with(grug_file_path, "ok/addition_as_two_arguments/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"addition_as_two_arguments"SLASH)) {
         CALL(grug_state, max, grug_number(3.0), grug_number(9.0));
-    } else if (starts_with(grug_file_path, "ok/addition_with_multiplication/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"addition_with_multiplication"SLASH)) {
         CALL(grug_state, initialize, grug_number(14.0));
-    } else if (starts_with(grug_file_path, "ok/addition_with_multiplication_2/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"addition_with_multiplication_2"SLASH)) {
         CALL(grug_state, initialize, grug_number(10.0));
-    } else if (starts_with(grug_file_path, "ok/and_false_1/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"and_false_1"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/and_false_2/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"and_false_2"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/and_false_3/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"and_false_3"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/and_short_circuit/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"and_short_circuit"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/and_true/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"and_true"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/blocked_alrm/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"blocked_alrm"SLASH)) {
         CALL_ARGLESS(grug_state, blocked_alrm);
-    } else if (starts_with(grug_file_path, "ok/bool_logical_not_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"bool_logical_not_false"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/bool_logical_not_true/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"bool_logical_not_true"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/bool_returned/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"bool_returned"SLASH)) {
         CALL_ARGLESS(grug_state, get_false);
         CALL(grug_state, set_is_happy, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/bool_returned_global/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"bool_returned_global"SLASH)) {
         CALL_ARGLESS(grug_state, get_false);
         CALL(grug_state, set_is_happy, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/bool_zero_extended_if_statement/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"bool_zero_extended_if_statement"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, get_false);
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/bool_zero_extended_while_statement/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"bool_zero_extended_while_statement"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, get_false);
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/break/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"break"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/calls_100/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"calls_100"SLASH)) {
         for (size_t i = 0; i < 100; i++) {
             CALL_ARGLESS(grug_state, nothing);
         }
-    } else if (starts_with(grug_file_path, "ok/calls_1000/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"calls_1000"SLASH)) {
         for (size_t i = 0; i < 1000; i++) {
             CALL_ARGLESS(grug_state, nothing);
         }
-    } else if (starts_with(grug_file_path, "ok/calls_in_call/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"calls_in_call"SLASH)) {
         CALL(grug_state, max, grug_number(1.0), grug_number(2.0));
         CALL(grug_state, max, grug_number(3.0), grug_number(4.0));
         CALL(grug_state, max, grug_number(2.0), grug_number(4.0));
         CALL(grug_state, initialize, grug_number(4.0));
-    } else if (starts_with(grug_file_path, "ok/comment_above_block/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"comment_above_block"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/comment_above_block_twice/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"comment_above_block_twice"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/comment_above_helper_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"comment_above_helper_fn"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/comment_above_on_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"comment_above_on_fn"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/comment_between_statements/")) {
-        CALL_ARGLESS(grug_state, nothing);
-        CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/comment_lone_block/")) {
-        CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/comment_lone_block_at_end/")) {
-        CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/comment_lone_global/")) {
-        CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/continue/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"comment_between_statements"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/custom_id_decays_to_id/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"comment_lone_block"SLASH)) {
+        CALL_ARGLESS(grug_state, nothing);
+    } else if (starts_with(grug_file_path, "ok"SLASH"comment_lone_block_at_end"SLASH)) {
+        CALL_ARGLESS(grug_state, nothing);
+    } else if (starts_with(grug_file_path, "ok"SLASH"comment_lone_global"SLASH)) {
+        CALL_ARGLESS(grug_state, nothing);
+    } else if (starts_with(grug_file_path, "ok"SLASH"continue"SLASH)) {
+        CALL_ARGLESS(grug_state, nothing);
+        CALL_ARGLESS(grug_state, nothing);
+    } else if (starts_with(grug_file_path, "ok"SLASH"custom_id_decays_to_id"SLASH)) {
         CALL(grug_state, store, grug_id(42));
-    } else if (starts_with(grug_file_path, "ok/custom_id_transfer_between_globals/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"custom_id_transfer_between_globals"SLASH)) {
         CALL(grug_state, set_opponent, grug_id(69));
-    } else if (starts_with(grug_file_path, "ok/division_negative_result/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"division_negative_result"SLASH)) {
         CALL(grug_state, initialize, grug_number(-2.5));
-    } else if (starts_with(grug_file_path, "ok/division_positive_result/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"division_positive_result"SLASH)) {
         CALL(grug_state, initialize, grug_number(2.5));
-    } else if (starts_with(grug_file_path, "ok/double_negation_with_parentheses/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"double_negation_with_parentheses"SLASH)) {
         CALL(grug_state, initialize, grug_number(2.0));
-    } else if (starts_with(grug_file_path, "ok/double_not_with_parentheses/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"double_not_with_parentheses"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/else_after_else_if_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"else_after_else_if_false"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/else_after_else_if_true/")) {
-        CALL_ARGLESS(grug_state, nothing);
-        CALL_ARGLESS(grug_state, nothing);
-        CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/else_false/")) {
-        CALL_ARGLESS(grug_state, nothing);
-        CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/else_if_false/")) {
-        CALL_ARGLESS(grug_state, nothing);
-        CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/else_if_true/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"else_after_else_if_true"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/else_true/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"else_false"SLASH)) {
+        CALL_ARGLESS(grug_state, nothing);
+        CALL_ARGLESS(grug_state, nothing);
+    } else if (starts_with(grug_file_path, "ok"SLASH"else_if_false"SLASH)) {
+        CALL_ARGLESS(grug_state, nothing);
+        CALL_ARGLESS(grug_state, nothing);
+    } else if (starts_with(grug_file_path, "ok"SLASH"else_if_true"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/empty_line/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"else_true"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/entity_and_resource_as_subexpression/")) {
+        CALL_ARGLESS(grug_state, nothing);
+    } else if (starts_with(grug_file_path, "ok"SLASH"empty_line"SLASH)) {
+        CALL_ARGLESS(grug_state, nothing);
+        CALL_ARGLESS(grug_state, nothing);
+    } else if (starts_with(grug_file_path, "ok"SLASH"entity_and_resource_as_subexpression"SLASH)) {
         CALL(grug_state, initialize_bool,
             grug_bool(
-                CALL(grug_state, has_resource, grug_string("ok/entity_and_resource_as_subexpression/foo.txt"))._bool
+                CALL(grug_state, has_resource, grug_string("ok"SLASH"entity_and_resource_as_subexpression"SLASH"foo.txt"))._bool
                 && CALL(grug_state, has_string, grug_string("bar"))._bool
                 && CALL(grug_state, has_entity, grug_string("ok:baz"))._bool
             )
         );
-    } else if (starts_with(grug_file_path, "ok/entity_duplicate/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"entity_duplicate"SLASH)) {
         CALL(grug_state, spawn, grug_string("ok:foo"));
         CALL(grug_state, spawn, grug_string("ok:bar"));
         CALL(grug_state, spawn, grug_string("ok:bar"));
         CALL(grug_state, spawn, grug_string("ok:baz"));
-    } else if (starts_with(grug_file_path, "ok/entity_in_on_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"entity_in_on_fn"SLASH)) {
         CALL(grug_state, spawn, grug_string("ok:foo"));
-    } else if (starts_with(grug_file_path, "ok/entity_in_on_fn_with_mod_specified/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"entity_in_on_fn_with_mod_specified"SLASH)) {
         CALL(grug_state, spawn, grug_string("wow:foo"));
-    } else if (starts_with(grug_file_path, "ok/eq_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"eq_false"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/eq_true/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"eq_true"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/f32_addition/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_addition"SLASH)) {
         CALL(grug_state, sin, grug_number(6.0));
-    } else if (starts_with(grug_file_path, "ok/f32_argument/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_argument"SLASH)) {
         CALL(grug_state, sin, grug_number(4.0));
-    } else if (starts_with(grug_file_path, "ok/f32_division/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_division"SLASH)) {
         CALL(grug_state, sin, grug_number(0.5));
-    } else if (starts_with(grug_file_path, "ok/f32_eq_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_eq_false"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/f32_eq_true/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_eq_true"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/f32_ge_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_ge_false"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/f32_ge_true_1/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_ge_true_1"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/f32_ge_true_2/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_ge_true_2"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/f32_global_variable/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_global_variable"SLASH)) {
         CALL(grug_state, sin, grug_number(4.0));
-    } else if (starts_with(grug_file_path, "ok/f32_gt_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_gt_false"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/f32_gt_true/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_gt_true"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/f32_le_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_le_false"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/f32_le_true_1/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_le_true_1"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/f32_le_true_2/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_le_true_2"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/f32_local_variable/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_local_variable"SLASH)) {
         CALL(grug_state, sin, grug_number(4.0));
-    } else if (starts_with(grug_file_path, "ok/f32_lt_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_lt_false"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/f32_lt_true/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_lt_true"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/f32_multiplication/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_multiplication"SLASH)) {
         CALL(grug_state, sin, grug_number(8.0));
-    } else if (starts_with(grug_file_path, "ok/f32_ne_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_ne_false"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/f32_negated/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_negated"SLASH)) {
         CALL(grug_state, sin, grug_number(-4.0));
-    } else if (starts_with(grug_file_path, "ok/f32_ne_true/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_ne_true"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/f32_passed_to_helper_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_passed_to_helper_fn"SLASH)) {
         CALL(grug_state, sin, grug_number(42.0));
-    } else if (starts_with(grug_file_path, "ok/f32_passed_to_on_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_passed_to_on_fn"SLASH)) {
         CALL(grug_state, sin, grug_number(42.0));
-    } else if (starts_with(grug_file_path, "ok/f32_passing_sin_to_cos/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_passing_sin_to_cos"SLASH)) {
         CALL(grug_state, cos, CALL(grug_state, sin, grug_number(4.0)));
-    } else if (starts_with(grug_file_path, "ok/f32_subtraction/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"f32_subtraction"SLASH)) {
         CALL(grug_state, sin, grug_number(-2.0));
-    } else if (starts_with(grug_file_path, "ok/fibonacci/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"fibonacci"SLASH)) {
         CALL(grug_state, initialize, grug_number(55.0));
-    } else if (starts_with(grug_file_path, "ok/ge_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"ge_false"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/ge_true_1/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"ge_true_1"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/ge_true_2/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"ge_true_2"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/global_call_using_me/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"global_call_using_me"SLASH"")) {
         CALL(grug_state, set_position, grug_id(1337));
-    } else if (starts_with(grug_file_path, "ok/global_can_use_earlier_global/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"global_can_use_earlier_global"SLASH)) {
         CALL(grug_state, initialize, grug_number(5.0));
-    } else if (starts_with(grug_file_path, "ok/global_containing_negation/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"global_containing_negation"SLASH)) {
         CALL(grug_state, initialize, grug_number(-2.0));
-    } else if (starts_with(grug_file_path, "ok/global_id/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"global_id"SLASH)) {
         CALL(grug_state, set_opponent, grug_id(69));
-    } else if (starts_with(grug_file_path, "ok/globals/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"globals"SLASH)) {
         CALL(grug_state, initialize, grug_number(420.0));
         CALL(grug_state, initialize, grug_number(1337.0));
-    } else if (starts_with(grug_file_path, "ok/gt_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"gt_false"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/gt_true/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"gt_true"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/helper_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"helper_fn"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/helper_fn_called_in_if/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"helper_fn_called_in_if"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/helper_fn_called_indirectly/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"helper_fn_called_indirectly"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/helper_fn_overwriting_param/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"helper_fn_overwriting_param"SLASH)) {
         CALL(grug_state, initialize, grug_number(20.0));
         CALL(grug_state, sin, grug_number(30.0));
-    } else if (starts_with(grug_file_path, "ok/helper_fn_returning_void_has_no_return/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"helper_fn_returning_void_has_no_return"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/helper_fn_returning_void_returns_void/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"helper_fn_returning_void_returns_void"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/helper_fn_same_param_name_as_on_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"helper_fn_same_param_name_as_on_fn"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/helper_fn_same_param_name_as_other_helper_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"helper_fn_same_param_name_as_other_helper_fn"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/i32_max/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"i32_max"SLASH)) {
         CALL(grug_state, initialize, grug_number(2147483647.0));
-    } else if (starts_with(grug_file_path, "ok/i32_min/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"i32_min"SLASH)) {
         CALL(grug_state, initialize, grug_number(-2147483648.0));
-    } else if (starts_with(grug_file_path, "ok/i32_negated/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"i32_negated"SLASH)) {
         CALL(grug_state, initialize, grug_number(-42.0));
-    } else if (starts_with(grug_file_path, "ok/i32_negative_is_smaller_than_positive/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"i32_negative_is_smaller_than_positive"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/id_binary_expr_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"id_binary_expr_false"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/id_binary_expr_true/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"id_binary_expr_true"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/id_eq_1/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"id_eq_1"SLASH)) {
         CALL_ARGLESS(grug_state, retrieve);
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/id_eq_2/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"id_eq_2"SLASH)) {
         CALL_ARGLESS(grug_state, retrieve);
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/id_global_with_id_to_new_id/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"id_global_with_id_to_new_id"SLASH)) {
         CALL(grug_state, store, grug_id(123));
-    } else if (starts_with(grug_file_path, "ok/id_global_with_opponent_to_new_id/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"id_global_with_opponent_to_new_id"SLASH)) {
         CALL(grug_state, store, grug_id(69));
-    } else if (starts_with(grug_file_path, "ok/id_helper_fn_param/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"id_helper_fn_param"SLASH)) {
         CALL(grug_state, store, CALL_ARGLESS(grug_state, retrieve));
-    } else if (starts_with(grug_file_path, "ok/id_local_variable_get_and_set/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"id_local_variable_get_and_set"SLASH)) {
         CALL(grug_state, set_opponent, CALL_ARGLESS(grug_state, get_opponent));
-    } else if (starts_with(grug_file_path, "ok/id_ne_1/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"id_ne_1"SLASH)) {
         CALL_ARGLESS(grug_state, retrieve);
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/id_ne_2/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"id_ne_2"SLASH)) {
         CALL_ARGLESS(grug_state, retrieve);
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/id_on_fn_param/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"id_on_fn_param"SLASH)) {
         CALL(grug_state, store, args[0]);
-    } else if (starts_with(grug_file_path, "ok/id_returned_from_helper/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"id_returned_from_helper"SLASH)) {
         CALL(grug_state, store, grug_id(42));
-    } else if (starts_with(grug_file_path, "ok/id_with_d_to_new_id_and_id_to_old_id/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"id_with_d_to_new_id_and_id_to_old_id"SLASH)) {
         CALL(grug_state, store, CALL_ARGLESS(grug_state, retrieve));
-    } else if (starts_with(grug_file_path, "ok/id_with_d_to_old_id/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"id_with_d_to_old_id"SLASH)) {
         CALL(grug_state, store, grug_id(42));
-    } else if (starts_with(grug_file_path, "ok/id_with_id_to_new_id/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"id_with_id_to_new_id"SLASH)) {
         CALL(grug_state, store, CALL_ARGLESS(grug_state, retrieve));
-    } else if (starts_with(grug_file_path, "ok/if_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"if_false"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/if_true/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"if_true"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/le_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"le_false"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/le_true_1/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"le_true_1"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/le_true_2/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"le_true_2"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/local_id_can_be_reassigned/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"local_id_can_be_reassigned"SLASH)) {
         CALL_ARGLESS(grug_state, get_opponent);
         CALL_ARGLESS(grug_state, get_opponent);
-    } else if (starts_with(grug_file_path, "ok/lt_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"lt_false"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/lt_true/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"lt_true"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/max_args/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"max_args"SLASH)) {
         CALL(grug_state, mega, grug_number(1.0), grug_number(21.0), grug_bool(true), grug_number(2.0), grug_number(3.0), grug_number(4.0), grug_bool(false), grug_number(1337.0), grug_number(5.0), grug_number(6.0), grug_number(7.0), grug_number(8.0), grug_id(42), grug_string("foo"));
-    } else if (starts_with(grug_file_path, "ok/me/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"me"SLASH"")) {
         CALL(grug_state, set_d, grug_id(42));
-    } else if (starts_with(grug_file_path, "ok/me_assigned_to_local_variable/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"me_assigned_to_local_variable"SLASH)) {
         CALL(grug_state, set_d, grug_id(42));
-    } else if (starts_with(grug_file_path, "ok/me_passed_to_helper_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"me_passed_to_helper_fn"SLASH)) {
         CALL(grug_state, set_d, grug_id(42));
-    } else if (starts_with(grug_file_path, "ok/multiplication_as_two_arguments/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"multiplication_as_two_arguments"SLASH)) {
         CALL(grug_state, max, grug_number(6.0), grug_number(20.0));
-    } else if (starts_with(grug_file_path, "ok/ne_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"ne_false"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/ne_true/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"ne_true"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/negate_parenthesized_expr/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"negate_parenthesized_expr"SLASH)) {
         CALL(grug_state, initialize, grug_number(-5.0));
-    } else if (starts_with(grug_file_path, "ok/negative_literal/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"negative_literal"SLASH)) {
         CALL(grug_state, initialize, grug_number(-42.0));
-    } else if (starts_with(grug_file_path, "ok/nested_break/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"nested_break"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/nested_continue/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"nested_continue"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/no_empty_line_between_statements/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"no_empty_line_between_statements"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/on_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"on_fn"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/on_fn_calling_game_fn_nothing/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"on_fn_calling_game_fn_nothing"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/on_fn_calling_game_fn_nothing_twice/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"on_fn_calling_game_fn_nothing_twice"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/on_fn_calling_game_fn_plt_order/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"on_fn_calling_game_fn_plt_order"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, magic);
         CALL(grug_state, initialize, grug_number(42.0));
         CALL(grug_state, identity, grug_number(69.0));
         CALL(grug_state, max, grug_number(1337.0), grug_number(8192.0));
-    } else if (starts_with(grug_file_path, "ok/on_fn_calling_helper_fns/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"on_fn_calling_helper_fns"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL(grug_state, initialize, grug_number(42.0));
-    } else if (starts_with(grug_file_path, "ok/on_fn_calling_no_game_fn/")) {
-    } else if (starts_with(grug_file_path, "ok/on_fn_calling_no_game_fn_but_with_addition/")) {
-    } else if (starts_with(grug_file_path, "ok/on_fn_calling_no_game_fn_but_with_global/")) {
-    } else if (starts_with(grug_file_path, "ok/on_fn_overwriting_param/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"on_fn_calling_no_game_fn"SLASH)) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"on_fn_calling_no_game_fn_but_with_addition"SLASH)) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"on_fn_calling_no_game_fn_but_with_global"SLASH)) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"on_fn_overwriting_param"SLASH)) {
         CALL(grug_state, initialize, grug_number(20.0));
         CALL(grug_state, sin, grug_number(30));
-    } else if (starts_with(grug_file_path, "ok/on_fn_passing_argument_to_helper_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"on_fn_passing_argument_to_helper_fn"SLASH)) {
         CALL(grug_state, initialize, grug_number(42.0));
-    } else if (starts_with(grug_file_path, "ok/on_fn_passing_magic_to_initialize/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"on_fn_passing_magic_to_initialize"SLASH)) {
         CALL(grug_state, initialize, CALL_ARGLESS(grug_state, magic));
-    } else if (starts_with(grug_file_path, "ok/on_fn_three/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"on_fn_three"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/on_fn_three_unused_first/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"on_fn_three_unused_first"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/on_fn_three_unused_second/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"on_fn_three_unused_second"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/on_fn_three_unused_third/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"on_fn_three_unused_third"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/or_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"or_false"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/or_short_circuit/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"or_short_circuit"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/or_true_1/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"or_true_1"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/or_true_2/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"or_true_2"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/or_true_3/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"or_true_3"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/pass_string_argument_to_game_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"pass_string_argument_to_game_fn"SLASH)) {
         CALL(grug_state, say, grug_string("foo"));
-    } else if (starts_with(grug_file_path, "ok/pass_string_argument_to_helper_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"pass_string_argument_to_helper_fn"SLASH)) {
         CALL(grug_state, say, grug_string("foo"));
-    } else if (starts_with(grug_file_path, "ok/resource_and_entity/")) {
-        CALL(grug_state, draw, grug_string("ok/resource_and_entity/foo.txt"));
+    } else if (starts_with(grug_file_path, "ok"SLASH"resource_and_entity"SLASH)) {
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_and_entity"SLASH"foo.txt"));
         CALL(grug_state, spawn, grug_string("ok:foo"));
-    } else if (starts_with(grug_file_path, "ok/resource_can_contain_dot_1/")) {
-        CALL(grug_state, draw, grug_string("ok/resource_can_contain_dot_1/.foo"));
-    } else if (starts_with(grug_file_path, "ok/resource_can_contain_dot_2/")) {
-        CALL(grug_state, draw, grug_string("ok/resource_can_contain_dot_2/foo."));
-    } else if (starts_with(grug_file_path, "ok/resource_can_contain_dot_3/")) {
-        CALL(grug_state, draw, grug_string("ok/resource_can_contain_dot_3/foo.bar"));
-    } else if (starts_with(grug_file_path, "ok/resource_can_contain_dot_dot_1/")) {
-        CALL(grug_state, draw, grug_string("ok/resource_can_contain_dot_dot_1/..foo"));
-    } else if (starts_with(grug_file_path, "ok/resource_can_contain_dot_dot_2/")) {
-        CALL(grug_state, draw, grug_string("ok/resource_can_contain_dot_dot_2/foo.."));
-    } else if (starts_with(grug_file_path, "ok/resource_can_contain_dot_dot_3/")) {
-        CALL(grug_state, draw, grug_string("ok/resource_can_contain_dot_dot_3/foo..bar"));
-    } else if (starts_with(grug_file_path, "ok/resource_duplicate/")) {
-        CALL(grug_state, draw, grug_string("ok/resource_duplicate/foo.txt"));
-        CALL(grug_state, draw, grug_string("ok/resource_duplicate/bar.txt"));
-        CALL(grug_state, draw, grug_string("ok/resource_duplicate/bar.txt"));
-        CALL(grug_state, draw, grug_string("ok/resource_duplicate/baz.txt"));
-    } else if (starts_with(grug_file_path, "ok/return/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"resource_can_contain_dot_1"SLASH)) {
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_1"SLASH".foo"));
+    } else if (starts_with(grug_file_path, "ok"SLASH"resource_can_contain_dot_2"SLASH)) {
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_2"SLASH"foo."));
+    } else if (starts_with(grug_file_path, "ok"SLASH"resource_can_contain_dot_3"SLASH)) {
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_3"SLASH"foo.bar"));
+    } else if (starts_with(grug_file_path, "ok"SLASH"resource_can_contain_dot_dot_1"SLASH)) {
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_dot_1"SLASH"..foo"));
+    } else if (starts_with(grug_file_path, "ok"SLASH"resource_can_contain_dot_dot_2"SLASH)) {
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_dot_2"SLASH"foo.."));
+    } else if (starts_with(grug_file_path, "ok"SLASH"resource_can_contain_dot_dot_3"SLASH)) {
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_can_contain_dot_dot_3"SLASH"foo..bar"));
+    } else if (starts_with(grug_file_path, "ok"SLASH"resource_duplicate"SLASH)) {
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_duplicate"SLASH"foo.txt"));
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_duplicate"SLASH"bar.txt"));
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_duplicate"SLASH"bar.txt"));
+        CALL(grug_state, draw, grug_string("ok"SLASH"resource_duplicate"SLASH"baz.txt"));
+    } else if (starts_with(grug_file_path, "ok"SLASH"return"SLASH)) {
         CALL(grug_state, initialize, grug_number(42.0));
-    } else if (starts_with(grug_file_path, "ok/return_from_on_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"return_from_on_fn"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/return_from_on_fn_minimal/")) {
-    } else if (starts_with(grug_file_path, "ok/return_with_no_value/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"return_from_on_fn_minimal"SLASH)) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"return_with_no_value"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/same_variable_name_in_different_functions/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"same_variable_name_in_different_functions"SLASH)) {
         CALL(grug_state, initialize, grug_number(42.0));
         CALL(grug_state, initialize, grug_number(69.0));
-    } else if (starts_with(grug_file_path, "ok/spill_args_to_game_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"spill_args_to_game_fn"SLASH)) {
         CALL(grug_state, motherload, grug_number(1.0), grug_number(2.0), grug_number(3.0), grug_number(4.0), grug_number(5.0), grug_number(6.0), grug_number(7.0), grug_number(1.0), grug_number(2.0), grug_number(3.0), grug_number(4.0), grug_number(5.0), grug_number(6.0), grug_number(7.0), grug_number(8.0), grug_id(42), grug_number(9.0));
-    } else if (starts_with(grug_file_path, "ok/spill_args_to_game_fn_subless/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"spill_args_to_game_fn_subless"SLASH)) {
         CALL(grug_state, motherload_subless, grug_number(1.0), grug_number(2.0), grug_number(3.0), grug_number(4.0), grug_number(5.0), grug_number(6.0), grug_number(7.0), grug_number(1.0), grug_number(2.0), grug_number(3.0), grug_number(4.0), grug_number(5.0), grug_number(6.0), grug_number(7.0), grug_number(8.0), grug_number(9.0), grug_id(42), grug_number(10.0));
-    } else if (starts_with(grug_file_path, "ok/spill_args_to_helper_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"spill_args_to_helper_fn"SLASH)) {
         CALL(grug_state, motherload, grug_number(1.0), grug_number(2.0), grug_number(3.0), grug_number(4.0), grug_number(5.0), grug_number(6.0), grug_number(7.0), grug_number(1.0), grug_number(2.0), grug_number(3.0), grug_number(4.0), grug_number(5.0), grug_number(6.0), grug_number(7.0), grug_number(8.0), grug_id(42), grug_number(9.0));
-    } else if (starts_with(grug_file_path, "ok/spill_args_to_helper_fn_32_bit_f32/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"spill_args_to_helper_fn_32_bit_f32"SLASH)) {
         CALL(grug_state, offset_32_bit_f32, grug_string("1"), grug_string("2"), grug_string("3"), grug_string("4"), grug_string("5"), grug_string("6"), grug_string("7"), grug_string("8"), grug_string("9"), grug_string("10"), grug_string("11"), grug_string("12"), grug_string("13"), grug_string("14"), grug_string("15"), grug_number(1.0), grug_number(2.0), grug_number(3.0), grug_number(4.0), grug_number(5.0), grug_number(6.0), grug_number(7.0), grug_number(8.0), grug_number(1.0));
-    } else if (starts_with(grug_file_path, "ok/spill_args_to_helper_fn_32_bit_i32/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"spill_args_to_helper_fn_32_bit_i32"SLASH)) {
         CALL(grug_state, offset_32_bit_i32, grug_number(1.0), grug_number(2.0), grug_number(3.0), grug_number(4.0), grug_number(5.0), grug_number(6.0), grug_number(7.0), grug_number(8.0), grug_number(9.0), grug_number(10.0), grug_number(11.0), grug_number(12.0), grug_number(13.0), grug_number(14.0), grug_number(15.0), grug_number(16.0), grug_number(17.0), grug_number(18.0), grug_number(19.0), grug_number(20.0), grug_number(21.0), grug_number(22.0), grug_number(23.0), grug_number(24.0), grug_number(25.0), grug_number(26.0), grug_number(27.0), grug_number(28.0), grug_number(29.0), grug_number(30.0), grug_number(1.0), grug_number(2.0), grug_number(3.0), grug_number(4.0), grug_number(5.0), grug_number(6.0));
-    } else if (starts_with(grug_file_path, "ok/spill_args_to_helper_fn_32_bit_string/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"spill_args_to_helper_fn_32_bit_string"SLASH)) {
         CALL(grug_state, offset_32_bit_string, grug_number(1.0), grug_number(2.0), grug_number(3.0), grug_number(4.0), grug_number(5.0), grug_number(6.0), grug_number(7.0), grug_number(8.0), grug_number(9.0), grug_number(10.0), grug_number(11.0), grug_number(12.0), grug_number(13.0), grug_number(14.0), grug_number(15.0), grug_number(16.0), grug_number(17.0), grug_number(18.0), grug_number(19.0), grug_number(20.0), grug_number(21.0), grug_number(22.0), grug_number(23.0), grug_number(24.0), grug_number(25.0), grug_number(26.0), grug_number(27.0), grug_number(28.0), grug_number(29.0), grug_number(30.0), grug_string("1"), grug_string("2"), grug_string("3"), grug_string("4"), grug_string("5"), grug_number(1.0));
-    } else if (starts_with(grug_file_path, "ok/spill_args_to_helper_fn_subless/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"spill_args_to_helper_fn_subless"SLASH)) {
         CALL(grug_state, motherload_subless, grug_number(1.0), grug_number(2.0), grug_number(3.0), grug_number(4.0), grug_number(5.0), grug_number(6.0), grug_number(7.0), grug_number(1.0), grug_number(2.0), grug_number(3.0), grug_number(4.0), grug_number(5.0), grug_number(6.0), grug_number(7.0), grug_number(8.0), grug_number(9.0), grug_id(42), grug_number(10.0));
-    } else if (starts_with(grug_file_path, "ok/stack_16_byte_alignment/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"stack_16_byte_alignment"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL(grug_state, initialize, grug_number(42.0));
-    } else if (starts_with(grug_file_path, "ok/stack_16_byte_alignment_midway/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"stack_16_byte_alignment_midway"SLASH)) {
         CALL(grug_state, initialize, grug_number(CALL_ARGLESS(grug_state, magic)._number + 42.0));
-    } else if (starts_with(grug_file_path, "ok/string_can_be_passed_to_helper_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"string_can_be_passed_to_helper_fn"SLASH)) {
         CALL(grug_state, say, grug_string("foo"));
-    } else if (starts_with(grug_file_path, "ok/string_duplicate/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"string_duplicate"SLASH)) {
         CALL(grug_state, talk, grug_string("foo"), grug_string("bar"), grug_string("bar"), grug_string("baz"));
-    } else if (starts_with(grug_file_path, "ok/string_eq_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"string_eq_false"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/string_eq_true/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"string_eq_true"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/string_eq_true_empty/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"string_eq_true_empty"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/string_ne_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"string_ne_false"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/string_ne_false_empty/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"string_ne_false_empty"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(false));
-    } else if (starts_with(grug_file_path, "ok/string_ne_true/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"string_ne_true"SLASH)) {
         CALL(grug_state, initialize_bool, grug_bool(true));
-    } else if (starts_with(grug_file_path, "ok/string_returned_by_game_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"string_returned_by_game_fn"SLASH)) {
         CALL(grug_state, has_string, CALL_ARGLESS(grug_state, get_os));
-    } else if (starts_with(grug_file_path, "ok/string_returned_by_game_fn_assigned_to_member/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"string_returned_by_game_fn_assigned_to_member"SLASH)) {
         CALL(grug_state, has_string, grug_string("foo"));
-    } else if (starts_with(grug_file_path, "ok/string_returned_by_helper_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"string_returned_by_helper_fn"SLASH)) {
         CALL(grug_state, has_string, grug_string("foo"));
-    } else if (starts_with(grug_file_path, "ok/string_returned_by_helper_fn_from_game_fn/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"string_returned_by_helper_fn_from_game_fn"SLASH)) {
         CALL(grug_state, has_string, CALL_ARGLESS(grug_state, get_os));
-    } else if (starts_with(grug_file_path, "ok/sub_rsp_32_bits_local_variables_i32/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"sub_rsp_32_bits_local_variables_i32"SLASH)) {
         for (int32_t n = 1; n <= 30; n++) {
             CALL(grug_state, initialize, grug_number(30.0));
         }
-    } else if (starts_with(grug_file_path, "ok/sub_rsp_32_bits_local_variables_id/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"sub_rsp_32_bits_local_variables_id"SLASH)) {
         for (size_t i = 0; i < 15; i++) {
             CALL(grug_state, set_d, grug_id(42));
         }
-    } else if (starts_with(grug_file_path, "ok/subtraction_negative_result/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"subtraction_negative_result"SLASH)) {
         CALL(grug_state, initialize, grug_number(-3.0));
-    } else if (starts_with(grug_file_path, "ok/subtraction_positive_result/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"subtraction_positive_result"SLASH)) {
         CALL(grug_state, initialize, grug_number(3.0));
-    } else if (starts_with(grug_file_path, "ok/variable/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"variable"SLASH)) {
         CALL(grug_state, initialize, grug_number(42.0));
-    } else if (starts_with(grug_file_path, "ok/variable_does_not_shadow_in_different_if_statement/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"variable_does_not_shadow_in_different_if_statement"SLASH)) {
         CALL(grug_state, initialize, grug_number(42.0));
         CALL(grug_state, initialize, grug_number(69.0));
-    } else if (starts_with(grug_file_path, "ok/variable_reassignment/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"variable_reassignment"SLASH)) {
         CALL(grug_state, initialize, grug_number(69.0));
-    } else if (starts_with(grug_file_path, "ok/variable_reassignment_does_not_dealloc_outer_variable/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"variable_reassignment_does_not_dealloc_outer_variable"SLASH)) {
         CALL(grug_state, initialize, grug_number(69.0));
-    } else if (starts_with(grug_file_path, "ok/variable_string_global/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"variable_string_global"SLASH)) {
         CALL(grug_state, say, grug_string("foo"));
-    } else if (starts_with(grug_file_path, "ok/variable_string_local/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"variable_string_local"SLASH)) {
         CALL(grug_state, say, grug_string("foo"));
-    } else if (starts_with(grug_file_path, "ok/void_function_early_return/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"void_function_early_return"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/while_false/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"while_false"SLASH)) {
         CALL_ARGLESS(grug_state, nothing);
         CALL_ARGLESS(grug_state, nothing);
-    } else if (starts_with(grug_file_path, "ok/write_to_global_variable/")) {
+    } else if (starts_with(grug_file_path, "ok"SLASH"write_to_global_variable"SLASH)) {
         CALL(grug_state, max, grug_number(43.0), grug_number(69.0));
     } else {
         assert(false);

--- a/tests.c
+++ b/tests.c
@@ -1545,7 +1545,7 @@ static void ok_entity_and_resource_as_subexpression(void* grug_state, void* file
 	assert_call_count(has_entity, 1);
 	assert_call_count(has_string, 1);
 
-	assert_string(game_fn_has_resource_path, "ok"SLASH"entity_and_resource_as_subexpression"SLASH"foo.txt");
+	assert_string(game_fn_has_resource_path, "ok"SLASH"entity_and_resource_as_subexpression/foo.txt");
 	assert_string(game_fn_has_entity_name, "ok:baz");
 	assert_string(game_fn_has_string_str, "bar");
 }
@@ -2491,7 +2491,7 @@ static void ok_resource_and_entity(void* grug_state, void* file_id) {
 	assert_call_count(draw, 1);
 	assert_call_count(spawn, 1);
 
-	assert_string(game_fn_draw_sprite_path, "ok"SLASH"resource_and_entity"SLASH"foo.txt");
+	assert_string(game_fn_draw_sprite_path, "ok"SLASH"resource_and_entity/foo.txt");
 	assert_string(game_fn_spawn_name, "ok:foo");
 }
 
@@ -2500,7 +2500,7 @@ static void ok_resource_can_contain_dot_1(void* grug_state, void* file_id) {
     call_export_fn_argless(grug_state, file_id, "on_a");
 	assert_call_count(draw, 1);
 
-	assert_string(game_fn_draw_sprite_path, "ok"SLASH"resource_can_contain_dot_1"SLASH".foo");
+	assert_string(game_fn_draw_sprite_path, "ok"SLASH"resource_can_contain_dot_1/.foo");
 }
 
 static void ok_resource_can_contain_dot_3(void* grug_state, void* file_id) {
@@ -2508,7 +2508,7 @@ static void ok_resource_can_contain_dot_3(void* grug_state, void* file_id) {
     call_export_fn_argless(grug_state, file_id, "on_a");
 	assert_call_count(draw, 1);
 
-	assert_string(game_fn_draw_sprite_path, "ok"SLASH"resource_can_contain_dot_3"SLASH"foo.bar");
+	assert_string(game_fn_draw_sprite_path, "ok"SLASH"resource_can_contain_dot_3/foo.bar");
 }
 
 static void ok_resource_can_contain_dot_dot_1(void* grug_state, void* file_id) {
@@ -2516,7 +2516,7 @@ static void ok_resource_can_contain_dot_dot_1(void* grug_state, void* file_id) {
     call_export_fn_argless(grug_state, file_id, "on_a");
 	assert_call_count(draw, 1);
 
-	assert_string(game_fn_draw_sprite_path, "ok"SLASH"resource_can_contain_dot_dot_1"SLASH"..foo");
+	assert_string(game_fn_draw_sprite_path, "ok"SLASH"resource_can_contain_dot_dot_1/..foo");
 }
 
 static void ok_resource_can_contain_dot_dot_3(void* grug_state, void* file_id) {
@@ -2524,7 +2524,7 @@ static void ok_resource_can_contain_dot_dot_3(void* grug_state, void* file_id) {
     call_export_fn_argless(grug_state, file_id, "on_a");
 	assert_call_count(draw, 1);
 
-	assert_string(game_fn_draw_sprite_path, "ok"SLASH"resource_can_contain_dot_dot_3"SLASH"foo..bar");
+	assert_string(game_fn_draw_sprite_path, "ok"SLASH"resource_can_contain_dot_dot_3/foo..bar");
 }
 
 static void ok_resource_duplicate(void* grug_state, void* file_id) {
@@ -2532,7 +2532,7 @@ static void ok_resource_duplicate(void* grug_state, void* file_id) {
     call_export_fn_argless(grug_state, file_id, "on_a");
 	assert_call_count(draw, 4);
 
-	assert_string(game_fn_draw_sprite_path, "ok"SLASH"resource_duplicate"SLASH"baz.txt");
+	assert_string(game_fn_draw_sprite_path, "ok"SLASH"resource_duplicate/baz.txt");
 }
 
 static void ok_return(void* grug_state, void* file_id) {

--- a/tests.c
+++ b/tests.c
@@ -77,8 +77,10 @@ static const char *get_type_name[] = {
 
 #if defined(_WIN32)
 #define mkdir(dir_path) mkdir(dir_path)
+#define SLASH "\\"
 #elif defined(__linux__)
 #define mkdir(dir_path) mkdir(dir_path, 0755)
+#define SLASH "/"
 #endif
 
 // From https://stackoverflow.com/a/2114249/13279557
@@ -947,10 +949,10 @@ static void print_string_debug(const char* str) {
 	if (is_whitelisted_test(#test_name)) {\
 		error_test_datas[err_test_datas_size++] = (struct error_test_data){\
 			.test_name_str = #test_name,\
-			.grug_path = "err/"#test_name"/input-"entity_type".grug",\
-			.expected_error_path = "err/"#test_name"/expected_error.txt",\
-			.results_path = "err/"#test_name"/results",\
-			.grug_output_path = "err/"#test_name"/results/grug_output.txt"\
+			.grug_path = "err"SLASH#test_name SLASH"input-"entity_type".grug",\
+			.expected_error_path = "err"SLASH#test_name SLASH"expected_error.txt",\
+			.results_path = "err"SLASH#test_name SLASH"results",\
+			.grug_output_path = "err"SLASH#test_name SLASH"results"SLASH"grug_output.txt"\
 		};\
 	}\
 } while (0)
@@ -961,10 +963,10 @@ static void print_string_debug(const char* str) {
 			.run = ok_##test_name,\
 			.file_id = NULL,\
 			.test_name_str = #test_name,\
-			.grug_path = "ok/"#test_name"/input-"entity_type".grug",\
-			.results_path = "ok/"#test_name"/results",\
-			.dump_path = "ok/"#test_name"/results/dump.json",\
-			.applied_path = "ok/"#test_name"/results/applied.grug",\
+			.grug_path = "ok"SLASH#test_name SLASH"input-"entity_type".grug",\
+			.results_path = "ok"SLASH#test_name SLASH"results",\
+			.dump_path = "ok"SLASH#test_name SLASH"results"SLASH"dump.json",\
+			.applied_path = "ok"SLASH#test_name SLASH"results"SLASH"applied.grug",\
 			.expected_globals_size_value = expected_globals_size\
 		};\
 	}\
@@ -976,11 +978,11 @@ static void print_string_debug(const char* str) {
 			.run = runtime_error_##test_name,\
 			.file_id = NULL,\
 			.test_name_str = #test_name,\
-			.grug_path = "err_runtime/"#test_name"/input-"entity_type".grug",\
-			.expected_error_path = "err_runtime/"#test_name"/expected_error.txt",\
-			.results_path = "err_runtime/"#test_name"/results",\
-			.dump_path = "err_runtime/"#test_name"/results/dump.json",\
-			.applied_path = "err_runtime/"#test_name"/results/applied.grug",\
+			.grug_path = "err_runtime"SLASH#test_name SLASH"input-"entity_type".grug",\
+			.expected_error_path = "err_runtime"SLASH#test_name SLASH"expected_error.txt",\
+			.results_path = "err_runtime"SLASH#test_name SLASH"results",\
+			.dump_path = "err_runtime"SLASH#test_name SLASH"results"SLASH"dump.json",\
+			.applied_path = "err_runtime"SLASH#test_name SLASH"results"SLASH"applied.grug",\
 			.expected_globals_size_value = expected_globals_size\
 		};\
 	}\
@@ -1543,7 +1545,7 @@ static void ok_entity_and_resource_as_subexpression(void* grug_state, void* file
 	assert_call_count(has_entity, 1);
 	assert_call_count(has_string, 1);
 
-	assert_string(game_fn_has_resource_path, "ok/entity_and_resource_as_subexpression/foo.txt");
+	assert_string(game_fn_has_resource_path, "ok"SLASH"entity_and_resource_as_subexpression"SLASH"foo.txt");
 	assert_string(game_fn_has_entity_name, "ok:baz");
 	assert_string(game_fn_has_string_str, "bar");
 }
@@ -2489,7 +2491,7 @@ static void ok_resource_and_entity(void* grug_state, void* file_id) {
 	assert_call_count(draw, 1);
 	assert_call_count(spawn, 1);
 
-	assert_string(game_fn_draw_sprite_path, "ok/resource_and_entity/foo.txt");
+	assert_string(game_fn_draw_sprite_path, "ok"SLASH"resource_and_entity"SLASH"foo.txt");
 	assert_string(game_fn_spawn_name, "ok:foo");
 }
 
@@ -2498,7 +2500,7 @@ static void ok_resource_can_contain_dot_1(void* grug_state, void* file_id) {
     call_export_fn_argless(grug_state, file_id, "on_a");
 	assert_call_count(draw, 1);
 
-	assert_string(game_fn_draw_sprite_path, "ok/resource_can_contain_dot_1/.foo");
+	assert_string(game_fn_draw_sprite_path, "ok"SLASH"resource_can_contain_dot_1"SLASH".foo");
 }
 
 static void ok_resource_can_contain_dot_3(void* grug_state, void* file_id) {
@@ -2506,7 +2508,7 @@ static void ok_resource_can_contain_dot_3(void* grug_state, void* file_id) {
     call_export_fn_argless(grug_state, file_id, "on_a");
 	assert_call_count(draw, 1);
 
-	assert_string(game_fn_draw_sprite_path, "ok/resource_can_contain_dot_3/foo.bar");
+	assert_string(game_fn_draw_sprite_path, "ok"SLASH"resource_can_contain_dot_3"SLASH"foo.bar");
 }
 
 static void ok_resource_can_contain_dot_dot_1(void* grug_state, void* file_id) {
@@ -2514,7 +2516,7 @@ static void ok_resource_can_contain_dot_dot_1(void* grug_state, void* file_id) {
     call_export_fn_argless(grug_state, file_id, "on_a");
 	assert_call_count(draw, 1);
 
-	assert_string(game_fn_draw_sprite_path, "ok/resource_can_contain_dot_dot_1/..foo");
+	assert_string(game_fn_draw_sprite_path, "ok"SLASH"resource_can_contain_dot_dot_1"SLASH"..foo");
 }
 
 static void ok_resource_can_contain_dot_dot_3(void* grug_state, void* file_id) {
@@ -2522,7 +2524,7 @@ static void ok_resource_can_contain_dot_dot_3(void* grug_state, void* file_id) {
     call_export_fn_argless(grug_state, file_id, "on_a");
 	assert_call_count(draw, 1);
 
-	assert_string(game_fn_draw_sprite_path, "ok/resource_can_contain_dot_dot_3/foo..bar");
+	assert_string(game_fn_draw_sprite_path, "ok"SLASH"resource_can_contain_dot_dot_3"SLASH"foo..bar");
 }
 
 static void ok_resource_duplicate(void* grug_state, void* file_id) {
@@ -2530,7 +2532,7 @@ static void ok_resource_duplicate(void* grug_state, void* file_id) {
     call_export_fn_argless(grug_state, file_id, "on_a");
 	assert_call_count(draw, 4);
 
-	assert_string(game_fn_draw_sprite_path, "ok/resource_duplicate/baz.txt");
+	assert_string(game_fn_draw_sprite_path, "ok"SLASH"resource_duplicate"SLASH"baz.txt");
 }
 
 static void ok_return(void* grug_state, void* file_id) {
@@ -3034,7 +3036,7 @@ static void runtime_error_all(void* grug_state, void* file_id) {
 	assert_runtime_error_type(GRUG_ON_FN_STACK_OVERFLOW);
 
 	assert_string(runtime_error_on_fn_name, "on_a");
-	assert_string(runtime_error_on_fn_path, "err_runtime/all/input-D.grug");
+	assert_string(runtime_error_on_fn_path, "err_runtime"SLASH"all"SLASH"input-D.grug");
 }
 
 static void runtime_error_game_fn_error(void* grug_state, void* file_id) {
@@ -3049,7 +3051,7 @@ static void runtime_error_game_fn_error(void* grug_state, void* file_id) {
 	assert_runtime_error_type(GRUG_ON_FN_GAME_FN_ERROR);
 
 	assert_string(runtime_error_on_fn_name, "on_a");
-	assert_string(runtime_error_on_fn_path, "err_runtime/game_fn_error/input-D.grug");
+	assert_string(runtime_error_on_fn_path, "err_runtime"SLASH"game_fn_error"SLASH"input-D.grug");
 }
 
 static void runtime_error_game_fn_error_once(void* grug_state, void* file_id) {
@@ -3064,7 +3066,7 @@ static void runtime_error_game_fn_error_once(void* grug_state, void* file_id) {
 	assert_runtime_error_type(GRUG_ON_FN_GAME_FN_ERROR);
 
 	assert_string(runtime_error_on_fn_name, "on_a");
-	assert_string(runtime_error_on_fn_path, "err_runtime/game_fn_error_once/input-E.grug");
+	assert_string(runtime_error_on_fn_path, "err_runtime"SLASH"game_fn_error_once"SLASH"input-E.grug");
 
 	had_runtime_error = false;
 
@@ -3080,7 +3082,7 @@ static void runtime_error_game_fn_error_once(void* grug_state, void* file_id) {
 }
 
 static void runtime_error_on_fn_calls_erroring_on_fn(void* grug_state, void* file_id) {
-	saved_grug_path = "err_runtime/on_fn_calls_erroring_on_fn/input-E.grug";
+	saved_grug_path = "err_runtime"SLASH"on_fn_calls_erroring_on_fn"SLASH"input-E.grug";
 
 	assert_call_count(call_on_b_fn, 0);
 	assert_call_count(cause_game_fn_error, 0);
@@ -3097,11 +3099,11 @@ static void runtime_error_on_fn_calls_erroring_on_fn(void* grug_state, void* fil
 	assert_runtime_error_type(GRUG_ON_FN_GAME_FN_ERROR);
 
 	assert_string(runtime_error_on_fn_name, "on_b");
-	assert_string(runtime_error_on_fn_path, "err_runtime/on_fn_calls_erroring_on_fn/input-E.grug");
+	assert_string(runtime_error_on_fn_path, "err_runtime"SLASH"on_fn_calls_erroring_on_fn"SLASH"input-E.grug");
 }
 
 static void runtime_error_on_fn_errors_after_it_calls_other_on_fn(void* grug_state, void* file_id) {
-	saved_grug_path = "err_runtime/on_fn_errors_after_it_calls_other_on_fn/input-E.grug";
+	saved_grug_path = "err_runtime"SLASH"on_fn_errors_after_it_calls_other_on_fn"SLASH"input-E.grug";
 
 	assert_call_count(call_on_b_fn, 0);
 	assert_call_count(nothing, 0);
@@ -3118,7 +3120,7 @@ static void runtime_error_on_fn_errors_after_it_calls_other_on_fn(void* grug_sta
 	assert_runtime_error_type(GRUG_ON_FN_GAME_FN_ERROR);
 
 	assert_string(runtime_error_on_fn_name, "on_a");
-	assert_string(runtime_error_on_fn_path, "err_runtime/on_fn_errors_after_it_calls_other_on_fn/input-E.grug");
+	assert_string(runtime_error_on_fn_path, "err_runtime"SLASH"on_fn_errors_after_it_calls_other_on_fn"SLASH"input-E.grug");
 }
 
 static void runtime_error_stack_overflow(void* grug_state, void* file_id) {
@@ -3129,7 +3131,7 @@ static void runtime_error_stack_overflow(void* grug_state, void* file_id) {
 	assert_runtime_error_type(GRUG_ON_FN_STACK_OVERFLOW);
 
 	assert_string(runtime_error_on_fn_name, "on_a");
-	assert_string(runtime_error_on_fn_path, "err_runtime/stack_overflow/input-D.grug");
+	assert_string(runtime_error_on_fn_path, "err_runtime"SLASH"stack_overflow"SLASH"input-D.grug");
 }
 
 static void runtime_error_time_limit_exceeded(void* grug_state, void* file_id) {
@@ -3140,7 +3142,7 @@ static void runtime_error_time_limit_exceeded(void* grug_state, void* file_id) {
 	assert_runtime_error_type(GRUG_ON_FN_TIME_LIMIT_EXCEEDED);
 
 	assert_string(runtime_error_on_fn_name, "on_a");
-	assert_string(runtime_error_on_fn_path, "err_runtime/time_limit_exceeded/input-D.grug");
+	assert_string(runtime_error_on_fn_path, "err_runtime"SLASH"time_limit_exceeded"SLASH"input-D.grug");
 }
 
 static void runtime_error_time_limit_exceeded_exponential_calls(void* grug_state, void* file_id) {
@@ -3151,7 +3153,7 @@ static void runtime_error_time_limit_exceeded_exponential_calls(void* grug_state
 	assert_runtime_error_type(GRUG_ON_FN_TIME_LIMIT_EXCEEDED);
 
 	assert_string(runtime_error_on_fn_name, "on_a");
-	assert_string(runtime_error_on_fn_path, "err_runtime/time_limit_exceeded_exponential_calls/input-D.grug");
+	assert_string(runtime_error_on_fn_path, "err_runtime"SLASH"time_limit_exceeded_exponential_calls"SLASH"input-D.grug");
 }
 
 static void runtime_error_time_limit_exceeded_fibonacci(void* grug_state, void* file_id) {
@@ -3162,7 +3164,7 @@ static void runtime_error_time_limit_exceeded_fibonacci(void* grug_state, void* 
 	assert_runtime_error_type(GRUG_ON_FN_TIME_LIMIT_EXCEEDED);
 
 	assert_string(runtime_error_on_fn_name, "on_a");
-	assert_string(runtime_error_on_fn_path, "err_runtime/time_limit_exceeded_fibonacci/input-D.grug");
+	assert_string(runtime_error_on_fn_path, "err_runtime"SLASH"time_limit_exceeded_fibonacci"SLASH"input-D.grug");
 }
 
 #define CHECK_THAT_EVERY_TEST_DIRECTORY_HAS_A_FUNCTION(test_dirname) do {\


### PR DESCRIPTION
added SLASH macro to smoketests and tests.c 

This replaces every occurrance of '/' in any path which is used by grug_tests except for the ones specified in resource strings in grug scripts.

This is done to ensure grug implementations on windows don't have to replace every instance of '\\' in their paths with '/' just to pass the tests. 

