### PR TITLE
feat: add tests/err/missing_empty_line_at_end_of_file test case

### DIFF
--- a/tests/err/missing_empty_line_at_end_of_file/expected_error.txt
+++ b/tests/err/missing_empty_line_at_end_of_file/expected_error.txt
@@ -1,0 +1,1 @@
+Expected an empty line, on line 4

--- a/tests/err/missing_empty_line_at_end_of_file/input-D.grug
+++ b/tests/err/missing_empty_line_at_end_of_file/input-D.grug
@@ -1,0 +1,3 @@
+on_a() {
+    nothing()
+}


### PR DESCRIPTION
Closes #43

Adds the missing `tests/err/missing_empty_line_at_end_of_file` test case as requested in issue #43.

The test verifies that grug correctly errors when a file ends without a trailing newline.

**Files added:**
- `tests/err/missing_empty_line_at_end_of_file/input-D.grug` — a valid grug file (`on_a()` with `nothing()`) that intentionally has no trailing newline
- - `tests/err/missing_empty_line_at_end_of_file/expected_error.txt` — `Expected an empty line, on line 4`
The error message pattern follows the same convention as other newline-related tests (e.g. `missing_empty_line_between_global_and_on_fn`).