### PR TITLE
feat: add tests/err/empty_line_before_else and tests/err/else_on_next_line test cases

### DIFF
--- a/tests/err/else_on_next_line/expected_error.txt
+++ b/tests/err/else_on_next_line/expected_error.txt
@@ -1,0 +1,1 @@
+Expected a statement token, but got token type ELSE_TOKEN on line 4

--- a/tests/err/else_on_next_line/input-D.grug
+++ b/tests/err/else_on_next_line/input-D.grug
@@ -1,0 +1,6 @@
+on_a() {
+    if true {
+    }
+    else {
+    }
+}

--- a/tests/err/empty_line_before_else/expected_error.txt
+++ b/tests/err/empty_line_before_else/expected_error.txt
@@ -1,0 +1,1 @@
+Expected a statement token, but got token type ELSE_TOKEN on line 5

--- a/tests/err/empty_line_before_else/input-D.grug
+++ b/tests/err/empty_line_before_else/input-D.grug
@@ -1,0 +1,7 @@
+on_a() {
+    if true {
+    }
+
+    else {
+    }
+}


### PR DESCRIPTION
## Summary

Adds two new error test cases for `else` statement newline handling as requested in #43.

### Changes

- **`tests/err/empty_line_before_else/`**: Tests that an empty line before `else` raises an error.
-   - `input-D.grug`: `if/else` block with an empty line between `}` and `else`
-   - `expected_error.txt`: `Expected a statement token, but got token type ELSE_TOKEN on line 5`
- **`tests/err/else_on_next_line/`**: Tests that `else` on the next line (without proper same-line placement) raises an error.
-   - `input-D.grug`: `if/else` block where `else` is on the line immediately following `}`
-   - `expected_error.txt`: `Expected a statement token, but got token type ELSE_TOKEN on line 4`
### How it works

In both cases the parser's `parse_if_statement` only looks for `else` when the next token after the closing `}` is a `SPACE_TOKEN`. If it's a `NEWLINE_TOKEN` (empty line) or if `else` ends up as the next statement on a new line, the outer `parse_statements` loop encounters `ELSE_TOKEN` as an unexpected statement token.

Closes #43