### PR TITLE
made one error more consistent with other errors

### DIFF
--- a/tests/err/cant_redefine_global/expected_error.txt
+++ b/tests/err/cant_redefine_global/expected_error.txt
@@ -1,1 +1,1 @@
-The global variable 'a' shadows an earlier global variable with the same name, so change the name of one of them
+The global variable 'a' shadows an earlier global variable


### PR DESCRIPTION
`The global variable 'a' shadows an earlier global variable with the same name, so change the name of one of them`

to 

`The global variable 'a' shadows an earlier global variable`