### PR TITLE
Put Linux-specific headers and functions behind `#ifdef`s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ tests.so
 tests.out
 tests.o
 build/*
+makefile

--- a/makefile
+++ b/makefile
@@ -1,6 +1,0 @@
-check:
-	cmake --build ./build
-
-run: check
-	./build/smoketest.exe
-

--- a/makefile
+++ b/makefile
@@ -1,0 +1,6 @@
+check:
+	cmake --build ./build
+
+run: check
+	./build/smoketest.exe
+

--- a/tests.c
+++ b/tests.c
@@ -2,7 +2,6 @@
 
 #include <assert.h>
 #include <ctype.h>
-/* #include <dirent.h> */
 #include <errno.h>
 #include <fcntl.h>
 #include <ftw.h>
@@ -12,7 +11,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-/* #include <unistd.h> */
 
 #define assert_call_count(game_fn_name, expected_count) do { \
 	size_t count = game_fn_ ## game_fn_name ## _call_count; \
@@ -79,7 +77,6 @@ static const char *get_type_name[] = {
 
 #if defined(_WIN32)
 #include<windows.h.>
-#define mkdir(dir_path) mkdir(dir_path)
 #define SLASH "\\"
 
 struct dirent {
@@ -139,10 +136,11 @@ int closedir(DIR* dir) {
 
 #elif defined(__linux__)
 #include <dirent.h>
-#define mkdir(dir_path) mkdir(dir_path, 0755)
+#include <unistd.h>
 #define SLASH "/"
 #endif
 
+int is_regular_file(const char* path);
 int is_regular_file(const char* path) {
 	struct stat st;
     if (stat(path, &st) < 0) {
@@ -1155,33 +1153,6 @@ static const char *get_expected_error(const char *expected_error_path) {
 	return expected_error;
 }
 
-/* static void make_results_dir(const char *results_path) { */
-/* 	if (mkdir(prefix(results_path)) == -1 && errno != EEXIST) { */
-/* 		perror("mkdir"); */
-/* 		fprintf(stderr, "prefix(results_path): \"%s\"\n", prefix(results_path));\ */
-/* 		exit(EXIT_FAILURE); */
-/* 	} */
-/* } */
-
-/* static int remove_callback(const char *entry_path, const struct stat *entry_info, int entry_type, struct FTW *ftw) { */
-/* 	(void)entry_info; */
-/* 	(void)entry_type; */
-/* 	(void)ftw; */
-
-/* 	int rv = remove(entry_path); */
-/* 	check(rv, "remove", entry_path); */
-
-/* 	return rv; */
-/* } */
-
-/* static void rm_rf(const char *path) { */
-/* 	int fd_limit = 42; */
-/* 	char buffer[4096]; */
-/* 	prefix_buf(path, buffer); */
-/* 	printf("rm_rf_path: %s\n", buffer); */
-/* 	check(nftw(path, remove_callback, fd_limit, FTW_DEPTH | FTW_PHYS), "nftw", path); */
-/* } */
-
 static int compare_filenames(const void *a, const void *b) {
     const char *str_a = *(const char * const *)a;
     const char *str_b = *(const char * const *)b;
@@ -1320,10 +1291,8 @@ static void test_error(
 	const char *results_path,
 	const char *grug_output_path
 ) {
+	(void)(results_path);
 	printf("Running tests/err/%s...\n", test_name);
-
-	/* rm_rf(results_path); */
-	/* make_results_dir(results_path); */
 
 	const char* msg = NULL;
 	compile_grug_file(grug_state, grug_path, &msg);
@@ -1450,8 +1419,7 @@ static void reset(void) {
 }
 
 static void* prologue(void* grug_state, const char *grug_path, const char *results_path) {
-	/* rm_rf(results_path); */
-	/* make_results_dir(results_path); */
+	(void)(results_path);
 
 	const char *msg = NULL;
 	void *file_id = compile_grug_file(grug_state, grug_path, &msg);

--- a/tests.c
+++ b/tests.c
@@ -143,6 +143,19 @@ int closedir(DIR* dir) {
 #define SLASH "/"
 #endif
 
+int is_regular_file(const char* path) {
+	struct stat st;
+    if (stat(path, &st) < 0) {
+		perror("stat");
+		exit(EXIT_FAILURE);
+	}
+
+    // Skip non-regular files (like directories, "." or "..")
+    if (!S_ISREG(st.st_mode)) {
+        return 0;
+    }
+	return 1;
+}
 // Most implementations shouldn't pass -DASSERT_ALIGNMENT.
 // It caught a ton of stack misalignment bugs
 // in the original version of grug.c, as it emitted raw machine code.
@@ -1142,29 +1155,32 @@ static const char *get_expected_error(const char *expected_error_path) {
 	return expected_error;
 }
 
-static void make_results_dir(const char *results_path) {
-	if (mkdir(prefix(results_path)) == -1 && errno != EEXIST) {
-		perror("mkdir");
-		fprintf(stderr, "prefix(results_path): \"%s\"\n", prefix(results_path));\
-		exit(EXIT_FAILURE);
-	}
-}
+/* static void make_results_dir(const char *results_path) { */
+/* 	if (mkdir(prefix(results_path)) == -1 && errno != EEXIST) { */
+/* 		perror("mkdir"); */
+/* 		fprintf(stderr, "prefix(results_path): \"%s\"\n", prefix(results_path));\ */
+/* 		exit(EXIT_FAILURE); */
+/* 	} */
+/* } */
 
-static int remove_callback(const char *entry_path, const struct stat *entry_info, int entry_type, struct FTW *ftw) {
-	(void)entry_info;
-	(void)entry_type;
-	(void)ftw;
+/* static int remove_callback(const char *entry_path, const struct stat *entry_info, int entry_type, struct FTW *ftw) { */
+/* 	(void)entry_info; */
+/* 	(void)entry_type; */
+/* 	(void)ftw; */
 
-	int rv = remove(entry_path);
-	check(rv, "remove", entry_path);
+/* 	int rv = remove(entry_path); */
+/* 	check(rv, "remove", entry_path); */
 
-	return rv;
-}
+/* 	return rv; */
+/* } */
 
-static int rm_rf(const char *path) {
-	int fd_limit = 42;
-	return nftw(path, remove_callback, fd_limit, FTW_DEPTH | FTW_PHYS);
-}
+/* static void rm_rf(const char *path) { */
+/* 	int fd_limit = 42; */
+/* 	char buffer[4096]; */
+/* 	prefix_buf(path, buffer); */
+/* 	printf("rm_rf_path: %s\n", buffer); */
+/* 	check(nftw(path, remove_callback, fd_limit, FTW_DEPTH | FTW_PHYS), "nftw", path); */
+/* } */
 
 static int compare_filenames(const void *a, const void *b) {
     const char *str_a = *(const char * const *)a;
@@ -1229,16 +1245,9 @@ static void run_single_test(struct grug_state *grug_state, const char *dir_path,
 		exit(EXIT_FAILURE);
 	}
 
-    struct stat st;
-    if (stat(grug_path, &st) < 0) {
-		perror("stat");
-		exit(EXIT_FAILURE);
+	if (!is_regular_file(grug_path)) {
+		return;
 	}
-
-    // Skip non-regular files (like directories, "." or "..")
-    if (!S_ISREG(st.st_mode)) {
-        return;
-    }
 
     printf("Running tests/%s...\n", relative_path);
 
@@ -1313,8 +1322,8 @@ static void test_error(
 ) {
 	printf("Running tests/err/%s...\n", test_name);
 
-	rm_rf(results_path);
-	make_results_dir(results_path);
+	/* rm_rf(results_path); */
+	/* make_results_dir(results_path); */
 
 	const char* msg = NULL;
 	compile_grug_file(grug_state, grug_path, &msg);
@@ -1441,8 +1450,8 @@ static void reset(void) {
 }
 
 static void* prologue(void* grug_state, const char *grug_path, const char *results_path) {
-	rm_rf(results_path);
-	make_results_dir(results_path);
+	/* rm_rf(results_path); */
+	/* make_results_dir(results_path); */
 
 	const char *msg = NULL;
 	void *file_id = compile_grug_file(grug_state, grug_path, &msg);

--- a/tests.c
+++ b/tests.c
@@ -2,7 +2,7 @@
 
 #include <assert.h>
 #include <ctype.h>
-#include <dirent.h>
+/* #include <dirent.h> */
 #include <errno.h>
 #include <fcntl.h>
 #include <ftw.h>
@@ -12,7 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <unistd.h>
+/* #include <unistd.h> */
 
 #define assert_call_count(game_fn_name, expected_count) do { \
 	size_t count = game_fn_ ## game_fn_name ## _call_count; \
@@ -78,9 +78,67 @@ static const char *get_type_name[] = {
 } while (0)
 
 #if defined(_WIN32)
+#include<windows.h.>
 #define mkdir(dir_path) mkdir(dir_path)
 #define SLASH "\\"
+
+struct dirent {
+	char d_name[MAX_PATH];
+};
+
+typedef struct {
+	HANDLE handle;
+	int first_taken;
+	struct dirent data;
+} DIR;
+
+DIR* opendir(const char* path);
+struct dirent* readdir(DIR*);
+int closedir(DIR*);
+
+DIR* opendir(const char* path) {
+	char path_buffer[4096];
+	snprintf(path_buffer, sizeof(path_buffer), "%s\\*", path);
+
+	printf("opendir path: %s\n", path_buffer);
+	WIN32_FIND_DATAA data = {0};
+	HANDLE handle = FindFirstFileA(path_buffer, &data);
+	if (handle == INVALID_HANDLE_VALUE) {
+		return NULL;
+	}
+	DIR* out = malloc(sizeof(DIR));
+	*out = (DIR) {
+		.handle = handle,
+		.first_taken = 0
+	};
+	strcpy(out->data.d_name, data.cFileName);
+	return out;
+}
+
+struct dirent* readdir(DIR* dir) {
+	if (!dir->first_taken) {
+		dir->first_taken = 1;
+		return &dir->data;
+	} else {
+		WIN32_FIND_DATAA data = {0};
+		if (FindNextFile(dir->handle, &data) == 0) {
+			return NULL;
+		}
+		strcpy(dir->data.d_name, data.cFileName);
+	}
+	return &dir->data; 
+}
+
+int closedir(DIR* dir) {
+	if (FindClose(dir->handle) == 0) {
+		return -1;
+	} else {
+		return 1;
+	}
+}
+
 #elif defined(__linux__)
+#include <dirent.h>
 #define mkdir(dir_path) mkdir(dir_path, 0755)
 #define SLASH "/"
 #endif


### PR DESCRIPTION
dirent.h, unistd.h, and ftw.h are not available on windows. These functions should be put behind the `__linux__` ifdef, and windows should provide equivalent functions with the same names

dirent.h and unistd.h have been fully replaced on windows. ftw.h is still needed because of `stat`. 