### PR TITLE
json roundtrip now puts the json string and output grug file into buffers in memory instead of going through the file system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ tests.out
 tests.o
 build/*
 makefile
+*.svg
+*.rad

--- a/smoketest.c
+++ b/smoketest.c
@@ -710,21 +710,15 @@ static bool copy_file(const char *src_path, const char *dst_path) {
     return false;
 }
 
-static size_t dump_file_to_json(struct grug_state* grug_state, const char *input_grug_path, char *output_buffer, size_t output_buffer_len) {
+static size_t dump_file_to_json(struct grug_state* grug_state, const char *input_buffer, char *output_buffer, size_t output_buffer_len) {
 	(void)grug_state;
-    FILE *src = fopen(input_grug_path, "r");
-    if (!src) {
-        perror("Failed to open source file");
-        fprintf(stderr, "path: %s\n", input_grug_path);
-        return (size_t)(-1);
-    }
-
-	size_t bytes_read = 0;
-	size_t cur_bytes_read;
-    while ((cur_bytes_read = fread(output_buffer, 1, output_buffer_len - bytes_read - 1, src)) > 0) {bytes_read += cur_bytes_read;}
-	// The last few bytes are being duplicated for some reason on windows
-	output_buffer[((bytes_read >= 1)?bytes_read - 1:0)] = '\0';
-	return bytes_read;
+	size_t input_len = strlen(input_buffer) + 1;
+	if (output_buffer_len < input_len) {
+		output_buffer[0] = '\0';
+		return output_buffer_len;
+	}
+	memmove(output_buffer, input_buffer, input_len);
+	return input_len;
 }
 
 static size_t generate_file_from_json(struct grug_state* grug_state, const char *input_buffer, char *output_buffer, size_t output_buffer_len) {

--- a/smoketest.c
+++ b/smoketest.c
@@ -671,26 +671,25 @@ static void call_export_fn(struct grug_state* grug_state, struct grug_file_id* f
     }
 }
 
-static size_t dump_file_to_json(struct grug_state* grug_state, const char *input_buffer, char *output_buffer, size_t output_buffer_len) {
+static bool dump_file_to_json(struct grug_state* grug_state, const char *input_buffer, char *output_buffer, size_t output_buffer_len) {
 	(void)grug_state;
 	size_t input_len = strlen(input_buffer) + 1;
 	if (output_buffer_len < input_len) {
-		output_buffer[0] = '\0';
-		return output_buffer_len;
+		return 1;
 	}
 	memmove(output_buffer, input_buffer, input_len);
-	return input_len;
+	return 0;
 }
 
-static size_t generate_file_from_json(struct grug_state* grug_state, const char *input_buffer, char *output_buffer, size_t output_buffer_len) {
+static bool generate_file_from_json(struct grug_state* grug_state, const char *input_buffer, char *output_buffer, size_t output_buffer_len) {
 	(void)grug_state;
 	size_t input_len = strlen(input_buffer) + 1;
 	if (output_buffer_len < input_len) {
 		output_buffer[0] = '\0';
-		return output_buffer_len;
+		return 1;
 	}
 	memmove(output_buffer, input_buffer, input_len);
-	return input_len;
+	return 0;
 }
 
 static void game_fn_error(struct grug_state* grug_state, const char *message) {

--- a/smoketest.c
+++ b/smoketest.c
@@ -710,14 +710,32 @@ static bool copy_file(const char *src_path, const char *dst_path) {
     return false;
 }
 
-static bool dump_file_to_json(struct grug_state* grug_state, const char *input_grug_path, const char *output_json_path) {
+static size_t dump_file_to_json(struct grug_state* grug_state, const char *input_grug_path, char *output_buffer, size_t output_buffer_len) {
 	(void)grug_state;
-    return copy_file(input_grug_path, output_json_path);
+    FILE *src = fopen(input_grug_path, "r");
+    if (!src) {
+        perror("Failed to open source file");
+        fprintf(stderr, "path: %s\n", input_grug_path);
+        return (size_t)(-1);
+    }
+
+	size_t bytes_read = 0;
+	size_t cur_bytes_read;
+    while ((cur_bytes_read = fread(output_buffer, 1, output_buffer_len - bytes_read - 1, src)) > 0) {bytes_read += cur_bytes_read;}
+	// The last few bytes are being duplicated for some reason on windows
+	output_buffer[((bytes_read >= 1)?bytes_read - 1:0)] = '\0';
+	return bytes_read;
 }
 
-static bool generate_file_from_json(struct grug_state* grug_state, const char *input_json_path, const char *output_grug_path) {
+static size_t generate_file_from_json(struct grug_state* grug_state, const char *input_buffer, char *output_buffer, size_t output_buffer_len) {
 	(void)grug_state;
-    return copy_file(input_json_path, output_grug_path);
+	size_t input_len = strlen(input_buffer) + 1;
+	if (output_buffer_len < input_len) {
+		output_buffer[0] = '\0';
+		return output_buffer_len;
+	}
+	memmove(output_buffer, input_buffer, input_len);
+	return input_len;
 }
 
 static void game_fn_error(struct grug_state* grug_state, const char *message) {

--- a/smoketest.c
+++ b/smoketest.c
@@ -671,45 +671,6 @@ static void call_export_fn(struct grug_state* grug_state, struct grug_file_id* f
     }
 }
 
-static bool copy_file(const char *src_path, const char *dst_path) {
-    FILE *src = fopen(src_path, "rb");
-    if (!src) {
-        perror("Failed to open source file");
-        fprintf(stderr, "path: %s\n", src_path);
-        return true;
-    }
-
-    FILE *dst = fopen(dst_path, "wb");
-    if (!dst) {
-        perror("Failed to open destination file");
-        fprintf(stderr, "path: %s\n", dst_path);
-        fclose(src);
-        return true;
-    }
-
-    char buffer[4096];
-    size_t bytes;
-    while ((bytes = fread(buffer, 1, sizeof(buffer), src)) > 0) {
-        if (fwrite(buffer, 1, bytes, dst) != bytes) {
-            perror("Write error");
-            fclose(src);
-            fclose(dst);
-            return true;
-        }
-    }
-
-    if (ferror(src)) {
-        perror("Read error");
-        fclose(src);
-        fclose(dst);
-        return true;
-    }
-
-    fclose(src);
-    fclose(dst);
-    return false;
-}
-
 static size_t dump_file_to_json(struct grug_state* grug_state, const char *input_buffer, char *output_buffer, size_t output_buffer_len) {
 	(void)grug_state;
 	size_t input_len = strlen(input_buffer) + 1;

--- a/tests.c
+++ b/tests.c
@@ -160,8 +160,6 @@ struct ok_test_data {
 	const char *test_name_str;
 	const char *grug_path;
 	const char *results_path;
-	const char *dump_path;
-	const char *applied_path;
 };
 static struct ok_test_data ok_test_datas[420420];
 static size_t ok_test_datas_size;
@@ -173,8 +171,6 @@ struct runtime_error_test_data {
 	const char *grug_path;
 	const char *expected_error_path;
 	const char *results_path;
-	const char *dump_path;
-	const char *applied_path;
 };
 static struct runtime_error_test_data runtime_error_test_datas[420420];
 static size_t err_runtime_test_datas_size;
@@ -970,8 +966,6 @@ static void print_string_debug(const char* str) {
 			.test_name_str = #test_name,\
 			.grug_path = "ok"SLASH#test_name SLASH"input-"entity_type".grug",\
 			.results_path = "ok"SLASH#test_name SLASH"results",\
-			.dump_path = "ok"SLASH#test_name SLASH"results"SLASH"dump.json",\
-			.applied_path = "ok"SLASH#test_name SLASH"results"SLASH"applied.grug"\
 		};\
 	}\
 } while (0)
@@ -985,8 +979,6 @@ static void print_string_debug(const char* str) {
 			.grug_path = "err_runtime"SLASH#test_name SLASH"input-"entity_type".grug",\
 			.expected_error_path = "err_runtime"SLASH#test_name SLASH"expected_error.txt",\
 			.results_path = "err_runtime"SLASH#test_name SLASH"results",\
-			.dump_path = "err_runtime"SLASH#test_name SLASH"results"SLASH"dump.json",\
-			.applied_path = "err_runtime"SLASH#test_name SLASH"results"SLASH"applied.grug"\
 		};\
 	}\
 } while (0)
@@ -1330,17 +1322,16 @@ static void test_error(
 
 static void diff_roundtrip(
 	void* grug_state,
-	const char *grug_path,
-	const char *dump_path,
-	const char *applied_path
+	const char *grug_path
 ) {
-	static char buf[4096];
-	if (dump_file_to_json(grug_state, prefix(grug_path), prefix_buf(dump_path, buf))) {
+	static char json_buf[65536];
+	if (dump_file_to_json(grug_state, prefix(grug_path), json_buf, sizeof(json_buf)) == (size_t)(-1)) {
 		fprintf(stderr, "Error: Failed to dump file AST\n");
 		exit(EXIT_FAILURE);
 	}
 
-	if (generate_file_from_json(grug_state, prefix(dump_path), prefix_buf(applied_path, buf))) {
+	static char applied_buf[65536];
+	if (generate_file_from_json(grug_state, json_buf, applied_buf, sizeof(applied_buf)) == (size_t)(-1)) {
 		fprintf(stderr, "Error: Failed to apply file AST\n");
 		exit(EXIT_FAILURE);
 	}
@@ -1349,14 +1340,10 @@ static void diff_roundtrip(
 	size_t grug_path_bytes_len = read_file(grug_path, grug_path_bytes);
 	grug_path_bytes[grug_path_bytes_len] = '\0';
 
-	static uint8_t applied_path_bytes[420420];
-	size_t applied_path_bytes_len = read_file(applied_path, applied_path_bytes);
-	applied_path_bytes[applied_path_bytes_len] = '\0';
-
-	if (!streq((const char *)grug_path_bytes, (const char *)applied_path_bytes)) {
+	if (!streq((const char *)grug_path_bytes, (const char *)applied_buf)) {
 		fprintf(stderr, "\nError: The roundtrip output differs from the expected output.\n");
 		fprintf(stderr, "Output:\n");
-		print_string_debug((const char *)applied_path_bytes);
+		print_string_debug((const char *)applied_buf);
 
 		fprintf(stderr, "Expected:\n");
 		print_string_debug((const char *)grug_path_bytes);
@@ -3944,7 +3931,7 @@ void grug_tests_run(
 
 		void* file_id = prologue(grug_state, fn_data->grug_path, fn_data->results_path);
 
-		diff_roundtrip(grug_state, fn_data->grug_path, fn_data->dump_path, fn_data->applied_path);
+		diff_roundtrip(grug_state, fn_data->grug_path);
 
 		init_globals(grug_state, file_id);
 		fn_data->file_id = file_id;
@@ -3973,7 +3960,7 @@ void grug_tests_run(
 
 		void* file_id = prologue(grug_state, fn_data->grug_path, fn_data->results_path);
 
-		diff_roundtrip(grug_state, fn_data->grug_path, fn_data->dump_path, fn_data->applied_path);
+		diff_roundtrip(grug_state, fn_data->grug_path);
 
 		init_globals(grug_state, file_id);
 		fn_data->file_id = file_id;

--- a/tests.c
+++ b/tests.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include <time.h>
 
-#define MiB(m) (m) * 1024 * 1024
+#define MiB (1024 * 1024)
 
 #define assert_call_count(game_fn_name, expected_count) do { \
 	size_t count = game_fn_ ## game_fn_name ## _call_count; \
@@ -1327,17 +1327,17 @@ static void diff_roundtrip(
 	void* grug_state,
 	const char *grug_path
 ) {
-	static uint8_t grug_path_bytes[MiB(1)];
+	static uint8_t grug_path_bytes[MiB];
 	size_t grug_path_bytes_len = read_file(grug_path, grug_path_bytes);
 	grug_path_bytes[grug_path_bytes_len] = '\0';
 
-	static char json_buf[MiB(1)];
+	static char json_buf[MiB];
 	if (dump_file_to_json(grug_state, (char*)grug_path_bytes, json_buf, sizeof(json_buf)) == (size_t)(-1)) {
 		fprintf(stderr, "Error: Failed to dump file AST\n");
 		exit(EXIT_FAILURE);
 	}
 
-	static char applied_buf[MiB(1)];
+	static char applied_buf[MiB];
 	if (generate_file_from_json(grug_state, json_buf, applied_buf, sizeof(applied_buf)) == (size_t)(-1)) {
 		fprintf(stderr, "Error: Failed to apply file AST\n");
 		exit(EXIT_FAILURE);

--- a/tests.c
+++ b/tests.c
@@ -1335,13 +1335,13 @@ static void diff_roundtrip(
 	grug_path_bytes[grug_path_bytes_len] = '\0';
 
 	static char json_buf[MiB];
-	if (dump_file_to_json(grug_state, (char*)grug_path_bytes, json_buf, sizeof(json_buf)) == (size_t)(-1)) {
+	if (dump_file_to_json(grug_state, (char*)grug_path_bytes, json_buf, sizeof(json_buf))) {
 		fprintf(stderr, "Error: Failed to dump file AST\n");
 		exit(EXIT_FAILURE);
 	}
 
 	static char applied_buf[MiB];
-	if (generate_file_from_json(grug_state, json_buf, applied_buf, sizeof(applied_buf)) == (size_t)(-1)) {
+	if (generate_file_from_json(grug_state, json_buf, applied_buf, sizeof(applied_buf))) {
 		fprintf(stderr, "Error: Failed to apply file AST\n");
 		exit(EXIT_FAILURE);
 	}

--- a/tests.c
+++ b/tests.c
@@ -1065,6 +1065,9 @@ static const char *get_expected_error(const char *expected_error_path) {
 	static char expected_error[420420];
 	size_t len = read_file(expected_error_path, (uint8_t *)expected_error);
 
+	if (len == 0) {
+		return "";
+	}
 	if (expected_error[len - 1] == '\n') {
 		len--;
 		if (expected_error[len - 1] == '\r') {

--- a/tests.c
+++ b/tests.c
@@ -11,6 +11,8 @@
 #include <string.h>
 #include <time.h>
 
+#define MiB(m) (m) * 1024 * 1024
+
 #define assert_call_count(game_fn_name, expected_count) do { \
 	size_t count = game_fn_ ## game_fn_name ## _call_count; \
 	if (count != expected_count) { \
@@ -1054,13 +1056,6 @@ static size_t read_file(const char *path, uint8_t *bytes) {
 		return 0;
 	}
 
-	if (bytes[len - 1] == '\n') {
-		len--;
-		if (bytes[len - 1] == '\r') {
-			len--;
-		}
-	}
-
 	bytes[len] = '\0';
 
 	return len;
@@ -1068,7 +1063,15 @@ static size_t read_file(const char *path, uint8_t *bytes) {
 
 static const char *get_expected_error(const char *expected_error_path) {
 	static char expected_error[420420];
-	read_file(expected_error_path, (uint8_t *)expected_error);
+	size_t len = read_file(expected_error_path, (uint8_t *)expected_error);
+
+	if (expected_error[len - 1] == '\n') {
+		len--;
+		if (expected_error[len - 1] == '\r') {
+			len--;
+		}
+		expected_error[len] = '\0';
+	}
 
 	return expected_error;
 }
@@ -1324,21 +1327,21 @@ static void diff_roundtrip(
 	void* grug_state,
 	const char *grug_path
 ) {
-	static char json_buf[65536 * 1024];
-	if (dump_file_to_json(grug_state, prefix(grug_path), json_buf, sizeof(json_buf)) == (size_t)(-1)) {
+	static uint8_t grug_path_bytes[MiB(1)];
+	size_t grug_path_bytes_len = read_file(grug_path, grug_path_bytes);
+	grug_path_bytes[grug_path_bytes_len] = '\0';
+
+	static char json_buf[MiB(1)];
+	if (dump_file_to_json(grug_state, (char*)grug_path_bytes, json_buf, sizeof(json_buf)) == (size_t)(-1)) {
 		fprintf(stderr, "Error: Failed to dump file AST\n");
 		exit(EXIT_FAILURE);
 	}
 
-	static char applied_buf[65536 * 1024];
+	static char applied_buf[MiB(1)];
 	if (generate_file_from_json(grug_state, json_buf, applied_buf, sizeof(applied_buf)) == (size_t)(-1)) {
 		fprintf(stderr, "Error: Failed to apply file AST\n");
 		exit(EXIT_FAILURE);
 	}
-
-	static uint8_t grug_path_bytes[420420];
-	size_t grug_path_bytes_len = read_file(grug_path, grug_path_bytes);
-	grug_path_bytes[grug_path_bytes_len] = '\0';
 
 	if (!streq((const char *)grug_path_bytes, (const char *)applied_buf)) {
 		fprintf(stderr, "\nError: The roundtrip output differs from the expected output.\n");

--- a/tests.c
+++ b/tests.c
@@ -1324,13 +1324,13 @@ static void diff_roundtrip(
 	void* grug_state,
 	const char *grug_path
 ) {
-	static char json_buf[65536];
+	static char json_buf[65536 * 1024];
 	if (dump_file_to_json(grug_state, prefix(grug_path), json_buf, sizeof(json_buf)) == (size_t)(-1)) {
 		fprintf(stderr, "Error: Failed to dump file AST\n");
 		exit(EXIT_FAILURE);
 	}
 
-	static char applied_buf[65536];
+	static char applied_buf[65536 * 1024];
 	if (generate_file_from_json(grug_state, json_buf, applied_buf, sizeof(applied_buf)) == (size_t)(-1)) {
 		fprintf(stderr, "Error: Failed to apply file AST\n");
 		exit(EXIT_FAILURE);

--- a/tests.h
+++ b/tests.h
@@ -108,16 +108,16 @@ typedef void (*call_export_fn_t)(struct grug_state* state, struct grug_file_id* 
  * grug AST and generating a textual `.grug` source file from it.
  *
  * It should parse the grug file at `input_grug_path`, produce a JSON
- * representation of its AST, and write it to `output_buffer`. The output
+ * representation of its AST, and write it to `output_json_buffer`. The output
  * should be null terminated
  *
  * @param state Current active grug state.
- * @param input_buffer Buffer that contains the input grug_file.
- * @param output_buffer Buffer to write the output into.
+ * @param input_grug_buffer Buffer that contains the input grug_file.
+ * @param output_json_buffer Buffer to write the output into.
  * @param output_buffer_len Size of the output buffer currently allocated.
  * @return 1 if the there was an error while dumping the json, 0 otherwise
  */
-typedef bool (*dump_file_to_json_t)(struct grug_state* state, const char *input_buffer, char *output_buffer, size_t output_buffer_len);
+typedef bool (*dump_file_to_json_t)(struct grug_state* state, const char *input_grug_buffer, char *output_json_buffer, size_t output_buffer_len);
 
 /**
  * @typedef generate_file_from_json_t
@@ -130,12 +130,12 @@ typedef bool (*dump_file_to_json_t)(struct grug_state* state, const char *input_
  * and write it to `output_grug_path`.
  *
  * @param state Current active grug state.
- * @param input_buffer Buffer containing the AST JSON.
- * @param output_buffer Buffer to write the output into.
+ * @param input_json_buffer Buffer containing the AST JSON.
+ * @param output_grug_buffer Buffer to write the output into.
  * @param output_buffer_len Size of the output buffer currently allocated.
  * @return 1 if the there was an error while dumping the grug file, 0 otherwise
  */
-typedef bool (*generate_file_from_json_t)(struct grug_state* state, const char *input_buffer, char *output_buffer, size_t output_buffer_len);
+typedef bool (*generate_file_from_json_t)(struct grug_state* state, const char *input_json_buffer, char *output_grug_buffer, size_t output_buffer_len);
 
 /**
  * @typedef game_fn_error_t

--- a/tests.h
+++ b/tests.h
@@ -108,14 +108,19 @@ typedef void (*call_export_fn_t)(struct grug_state* state, struct grug_file_id* 
  * grug AST and generating a textual `.grug` source file from it.
  *
  * It should parse the grug file at `input_grug_path`, produce a JSON
- * representation of its AST, and write it to `output_json_path`.
+ * representation of its AST, and write it to `output_buffer`. The output
+ * should be null terminated
  *
  * @param state Current active grug state.
  * @param input_grug_path Path to the input `.grug` source file to be dumped.
- * @param output_json_path Path to write the produced JSON file.
- * @return `true` if an error occurred.
+ * @param output_buffer Buffer to write the output into.
+ * @param output_buffer_len Size of the output buffer currently allocated.
+ * @return the number of bytes written to the output, if the number of bytes
+ * is equal to size of the buffer, the buffer is discarded and the function is
+ * called again with a bigger buffer. If the returned size is (size_t)(-1),
+ * it indicates an error in the function
  */
-typedef bool (*dump_file_to_json_t)(struct grug_state* state, const char *input_grug_path, const char *output_json_path);
+typedef size_t (*dump_file_to_json_t)(struct grug_state* state, const char *input_grug_path, char *output_buffer, size_t output_buffer_len);
 
 /**
  * @typedef generate_file_from_json_t
@@ -124,15 +129,19 @@ typedef bool (*dump_file_to_json_t)(struct grug_state* state, const char *input_
  * All tests verify round-trip fidelity: reading a JSON representation of a
  * grug AST and generating a textual `.grug` source file from it.
  *
- * It should read the AST at `input_json_path`, generate the `.grug` text for it,
+ * It should read the AST from `input_json`, generate the `.grug` text for it,
  * and write it to `output_grug_path`.
  *
  * @param state Current active grug state.
- * @param input_json_path Path to the input JSON file containing the grug AST.
- * @param output_grug_path Path to write the generated `.grug` source file.
- * @return `true` if an error occurred.
+ * @param input_buffer Buffer containing the AST JSON.
+ * @param output_buffer Buffer to write the output into.
+ * @param output_buffer_len Size of the output buffer currently allocated.
+ * @return the number of bytes written to the output, if the number of bytes
+ * is equal to size of the buffer, the buffer is discarded and the function is
+ * called again with a bigger buffer. If the returned size is (size_t)(-1),
+ * it indicates an error in the function
  */
-typedef bool (*generate_file_from_json_t)(struct grug_state* state, const char *input_json_path, const char *output_grug_path);
+typedef size_t (*generate_file_from_json_t)(struct grug_state* state, const char *input_buffer, char *output_buffer, size_t output_buffer_len);
 
 /**
  * @typedef game_fn_error_t

--- a/tests.h
+++ b/tests.h
@@ -115,10 +115,8 @@ typedef void (*call_export_fn_t)(struct grug_state* state, struct grug_file_id* 
  * @param input_grug_path Path to the input `.grug` source file to be dumped.
  * @param output_buffer Buffer to write the output into.
  * @param output_buffer_len Size of the output buffer currently allocated.
- * @return the number of bytes written to the output, if the number of bytes
- * is equal to size of the buffer, the buffer is discarded and the function is
- * called again with a bigger buffer. If the returned size is (size_t)(-1),
- * it indicates an error in the function
+ * @return the number of bytes written to the output, If the returned size is
+ * (size_t)(-1), it indicates an error in the function
  */
 typedef size_t (*dump_file_to_json_t)(struct grug_state* state, const char *input_grug_path, char *output_buffer, size_t output_buffer_len);
 
@@ -136,10 +134,8 @@ typedef size_t (*dump_file_to_json_t)(struct grug_state* state, const char *inpu
  * @param input_buffer Buffer containing the AST JSON.
  * @param output_buffer Buffer to write the output into.
  * @param output_buffer_len Size of the output buffer currently allocated.
- * @return the number of bytes written to the output, if the number of bytes
- * is equal to size of the buffer, the buffer is discarded and the function is
- * called again with a bigger buffer. If the returned size is (size_t)(-1),
- * it indicates an error in the function
+ * @return the number of bytes written to the output, If the returned size is
+ * (size_t)(-1), it indicates an error in the function
  */
 typedef size_t (*generate_file_from_json_t)(struct grug_state* state, const char *input_buffer, char *output_buffer, size_t output_buffer_len);
 

--- a/tests.h
+++ b/tests.h
@@ -115,10 +115,9 @@ typedef void (*call_export_fn_t)(struct grug_state* state, struct grug_file_id* 
  * @param input_buffer Buffer that contains the input grug_file.
  * @param output_buffer Buffer to write the output into.
  * @param output_buffer_len Size of the output buffer currently allocated.
- * @return the number of bytes written to the output, If the returned size is
- * (size_t)(-1), it indicates an error in the function
+ * @return 1 if the there was an error while dumping the json, 0 otherwise
  */
-typedef size_t (*dump_file_to_json_t)(struct grug_state* state, const char *input_buffer, char *output_buffer, size_t output_buffer_len);
+typedef bool (*dump_file_to_json_t)(struct grug_state* state, const char *input_buffer, char *output_buffer, size_t output_buffer_len);
 
 /**
  * @typedef generate_file_from_json_t
@@ -134,10 +133,9 @@ typedef size_t (*dump_file_to_json_t)(struct grug_state* state, const char *inpu
  * @param input_buffer Buffer containing the AST JSON.
  * @param output_buffer Buffer to write the output into.
  * @param output_buffer_len Size of the output buffer currently allocated.
- * @return the number of bytes written to the output, If the returned size is
- * (size_t)(-1), it indicates an error in the function
+ * @return 1 if the there was an error while dumping the grug file, 0 otherwise
  */
-typedef size_t (*generate_file_from_json_t)(struct grug_state* state, const char *input_buffer, char *output_buffer, size_t output_buffer_len);
+typedef bool (*generate_file_from_json_t)(struct grug_state* state, const char *input_buffer, char *output_buffer, size_t output_buffer_len);
 
 /**
  * @typedef game_fn_error_t

--- a/tests.h
+++ b/tests.h
@@ -112,13 +112,13 @@ typedef void (*call_export_fn_t)(struct grug_state* state, struct grug_file_id* 
  * should be null terminated
  *
  * @param state Current active grug state.
- * @param input_grug_path Path to the input `.grug` source file to be dumped.
+ * @param input_buffer Buffer that contains the input grug_file.
  * @param output_buffer Buffer to write the output into.
  * @param output_buffer_len Size of the output buffer currently allocated.
  * @return the number of bytes written to the output, If the returned size is
  * (size_t)(-1), it indicates an error in the function
  */
-typedef size_t (*dump_file_to_json_t)(struct grug_state* state, const char *input_grug_path, char *output_buffer, size_t output_buffer_len);
+typedef size_t (*dump_file_to_json_t)(struct grug_state* state, const char *input_buffer, char *output_buffer, size_t output_buffer_len);
 
 /**
  * @typedef generate_file_from_json_t


### PR DESCRIPTION
On windows, a significant amount of time in the tests is spend reading and writing to the files when dumping to json and regenerating the grug file. 

Doing it in memory cuts the time taken to run the tests in more than half. 