### PR TITLE
made MSVCs analyser shut up

### DIFF
--- a/cJSON.c
+++ b/cJSON.c
@@ -1496,6 +1496,10 @@ static cJSON_bool print_value(const cJSON * const item, printbuffer * const outp
 /* Build an array from input text. */
 static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buffer)
 {
+	if (!input_buffer) {
+		fprintf(stderr, "UNREACHABLE");
+		exit(1);
+	}
     cJSON *head = NULL; /* head of the linked list */
     cJSON *current_item = NULL;
 

--- a/smoketest.c
+++ b/smoketest.c
@@ -757,7 +757,7 @@ static bool grug_to_json(struct grug_state* grug_state, const char *input_grug_b
 	(void)input_grug_buffer;
 
 	// Construct path to expected.json by replacing filename in saved_grug_file_path
-	char expected_json_path[1024];
+	char expected_json_path[1024] = {0};
 	size_t saved_path_len = strlen(saved_grug_file_path);
 	if (saved_path_len >= sizeof(expected_json_path)) {
 		return true;

--- a/tests.c
+++ b/tests.c
@@ -1397,13 +1397,13 @@ static void assert_jsons_are_equal(const char *actual_json, const char *expected
 }
 
 static char *get_expected_json_path(const char *grug_path) {
-	static char expected_json_path[MiB];
-	size_t grug_path_len = strlen(grug_path);
+	static char expected_json_path[MiB] = {0};
+	size_t grug_path_len = strlen(grug_path) + 1;
 	if (grug_path_len >= sizeof(expected_json_path)) {
 		fprintf(stderr, "Error: grug_path too long\n");
 		exit(EXIT_FAILURE);
 	}
-	memcpy(expected_json_path, grug_path, grug_path_len + 1);
+	memcpy(expected_json_path, grug_path, grug_path_len);
 		
 	// Find the last slash to replace the filename with expected.json
 	char *last_slash = strrchr(expected_json_path, SLASH[0]);


### PR DESCRIPTION
fixed off by one error in buffer memcpy. 

added zero initialization to buffers to make MSVC happy.
added assert to cJSON's parse_value to ensure input_buffer is never null (it could never be null)