### PR TITLE
split windows, linux, and python workflows in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: CI Build
+name: CI Build ubuntu
 
 on:
   push:
@@ -7,40 +7,21 @@ on:
 
 jobs:
   build:
-    name: Build ${{ matrix.os }} ${{ matrix.compiler }} ${{ matrix.sanitizer }}
-    runs-on: ${{ matrix.os }}
+    name: Build ubuntu ${{ matrix.compiler }} ${{ matrix.sanitizer }}
+    runs-on: ubuntu-latest
     continue-on-error: true
     defaults:
       run:
-        shell: ${{ matrix.os == 'windows-latest' && 'msys2 {0}' || 'bash' }}
+        shell: bash
     strategy:
       matrix:
         os: [ubuntu-latest]
         compiler: [clang, gcc]
         sanitizer: [none, asan, valgrind]
-        include:
-          - os: windows-latest
-            compiler: gcc
-            sanitizer: none
-          - os: windows-latest
-            compiler: msvc
-            sanitizer: none
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Setup MSYS2
-        if: matrix.os == 'windows-latest' 
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: MINGW64
-          path-type: inherit
-          update: true
-          install: >-
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-ninja
 
       - name: Install Valgrind (if needed)
         if: matrix.sanitizer == 'valgrind'
@@ -62,11 +43,7 @@ jobs:
             # The ,, lowercases it to build-debug and build-release
             export BUILD_DIR=build-${BUILD_TYPE,,} 
             
-            if [ "${{ matrix.compiler }}" == "msvc" ]; then
-              CMAKE_FLAGS=("-G" 'Visual Studio 17 2022')
-            else 
-              CMAKE_FLAGS=("-G" "Ninja" "-DCMAKE_BUILD_TYPE=$BUILD_TYPE")
-            fi
+            CMAKE_FLAGS=("-G" "Ninja" "-DCMAKE_BUILD_TYPE=$BUILD_TYPE" "-DCMAKE_C_COMPILER=${{ matrix.compiler }}")
 
             cmake -S . -B $BUILD_DIR "${CMAKE_FLAGS[@]}"
             cmake --build $BUILD_DIR --config=$BUILD_TYPE
@@ -80,29 +57,6 @@ jobs:
               "$TEST_EXE"
             fi
           done
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-
-      - name: Install Python dependencies
-        run: python -m pip install lark[interegular] pyright jsonschema
-
-      - name: Run grammar check
-        run: python grug_grammar.py
-
-      - name: Run JSON schema validation
-        run: python mod_api_schema.py
-
-      - name: Run Pyright type check
-        run: |
-          PY_MAJOR_MINOR=$(python - <<'EOF' | tr -d '\r'
-          import sys
-          print(f"{sys.version_info.major}.{sys.version_info.minor}")
-          EOF
-          )
-          pyright --pythonversion "$PY_MAJOR_MINOR"
 
         env:
           SHUFFLES: 10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ jobs:
   build:
     name: Build ubuntu ${{ matrix.compiler }} ${{ matrix.sanitizer }}
     runs-on: ubuntu-latest
-    continue-on-error: true
     defaults:
       run:
         shell: bash

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -1,0 +1,57 @@
+name: CI Build Grammar
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Grammar ${{ matrix.os }} 
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    defaults:
+      run:
+        shell: ${{ matrix.os == 'windows-latest' && 'msys2 {0}' || 'bash' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup MSYS2
+        if: matrix.os == 'windows-latest' 
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          path-type: inherit
+          update: false
+          install: >-
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install Python dependencies
+        run: python -m pip install lark[interegular] pyright jsonschema
+
+      - name: Run grammar check
+        run: python grug_grammar.py
+
+      - name: Run JSON schema validation
+        run: python mod_api_schema.py
+
+      - name: Run Pyright type check
+        run: |
+          PY_MAJOR_MINOR=$(python - <<'EOF' | tr -d '\r'
+          import sys
+          print(f"{sys.version_info.major}.{sys.version_info.minor}")
+          EOF
+          )
+          pyright --pythonversion "$PY_MAJOR_MINOR"
+
+        env:
+          SHUFFLES: 10

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -1,4 +1,4 @@
-name: CI Build
+name: CI Build Grammar
 
 on:
   push:

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -9,7 +9,6 @@ jobs:
   build:
     name: Grammar ${{ matrix.os }} 
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     defaults:
       run:
         shell: ${{ matrix.os == 'windows-latest' && 'msys2 {0}' || 'bash' }}

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -1,4 +1,4 @@
-name: CI Build Grammar
+name: CI Build
 
 on:
   push:

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -1,4 +1,4 @@
-name: CI Build
+name: CI Build Windows
 
 on:
   push:

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -9,7 +9,6 @@ jobs:
   build:
     name: Build windows ${{ matrix.compiler }} 
     runs-on: windows-latest
-    continue-on-error: true
     defaults:
       run:
         shell: pwsh

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -1,0 +1,50 @@
+name: CI Build windows
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build windows ${{ matrix.compiler }} 
+    runs-on: windows-latest
+    continue-on-error: true
+    defaults:
+      run:
+        shell: pwsh
+    strategy:
+      matrix:
+        compiler: [msvc, gcc]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build and run tests (Debug + Release)
+        run: |
+          foreach ($BUILD_TYPE in @("Debug", "Release")) {
+            Write-Host "=== Building $BUILD_TYPE ==="
+
+            $BUILD_DIR = "build-$($BUILD_TYPE.ToLower())"
+
+            if ("${{ matrix.compiler }}" -eq "msvc") {
+              $CMAKE_FLAGS = @("-G", "Visual Studio 17 2022")
+            } else {
+              $CMAKE_FLAGS = @("-G", "Ninja", "-DCMAKE_BUILD_TYPE=$BUILD_TYPE")
+            }
+
+            cmake -S . -B $BUILD_DIR @CMAKE_FLAGS
+            cmake --build $BUILD_DIR --config=@BUILD_TYPE
+
+            Write-Host "=== Running tests ($BUILD_TYPE) ==="
+
+            $TEST_EXE = Get-ChildItem -Path $BUILD_DIR -Recurse -File |
+              Where-Object { $_.Name -eq "smoketest" -or $_.Name -eq "smoketest.exe" } |
+              Select-Object -First 1
+
+            $TEST_EXE.FullName
+          }
+
+        env:
+          SHUFFLES: 10

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -15,7 +15,7 @@ jobs:
         shell: pwsh
     strategy:
       matrix:
-        compiler: [msvc, gcc]
+        compiler: [msvc, gcc, clang]
 
     steps:
       - name: Checkout code
@@ -31,7 +31,7 @@ jobs:
             if ("${{ matrix.compiler }}" -eq "msvc") {
               $CMAKE_FLAGS = @("-G", "Visual Studio 17 2022")
             } else {
-              $CMAKE_FLAGS = @("-G", "Ninja", "-DCMAKE_BUILD_TYPE=$BUILD_TYPE")
+              $CMAKE_FLAGS = @("-G", "Ninja", "-DCMAKE_BUILD_TYPE=$BUILD_TYPE" , "-DCMAKE_C_COMPILER=${{ matrix.compiler }}")
             }
 
             cmake -S . -B $BUILD_DIR @CMAKE_FLAGS

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -35,7 +35,7 @@ jobs:
             }
 
             cmake -S . -B $BUILD_DIR @CMAKE_FLAGS
-            cmake --build $BUILD_DIR --config=@BUILD_TYPE
+            cmake --build $BUILD_DIR --config=$BUILD_TYPE
 
             Write-Host "=== Running tests ($BUILD_TYPE) ==="
 

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -1,4 +1,4 @@
-name: CI Build windows
+name: CI Build
 
 on:
   push:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,6 @@ message(STATUS "Compilation will use ${CMAKE_C_COMPILER_ID}")
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 if (MSVC)
-	add_definitions(-D_CRT_SECURE_NO_WARNINGS)    
 	set(BASE_WARNINGS
 		/W4
 		/WX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ if (DEFINED WIN32)
     set_target_properties(tests PROPERTIES PREFIX "")
 endif()
 
-if (NOT(MSVC))
+if (NOT(DEFINED WIN32))
 	target_link_libraries(tests
 		PRIVATE
 			m

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ message(STATUS "Compilation will use ${CMAKE_C_COMPILER_ID}")
 # Base compiler flags
 # -----------------------------
 
+add_definitions(-D_CRT_SECURE_NO_WARNINGS)    
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 if (MSVC)
 	set(BASE_WARNINGS

--- a/cJSON.c
+++ b/cJSON.c
@@ -28,6 +28,18 @@
 #define _CRT_SECURE_NO_DEPRECATE
 #endif
 
+/* MinGW gcc defines isnan and isinf on floats which causes conversion
+ * warnings when using them with doubles, so we use the underlying
+ * intrinsics directly */
+#if defined(__MINGW64__)
+#define is_nan(d) _isnan(d)
+#define is_inf(d) (!_finite(d))
+#else 
+#define is_nan(d) isnan(d)
+#define is_inf(d) isinf(d)
+#endif
+
+
 #ifdef __GNUC__
 #pragma GCC visibility push(default)
 #endif
@@ -609,7 +621,7 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
     }
 
     /* This checks for NaN and Infinity */
-    if (isnan(d) || isinf(d))
+    if (is_nan(d) || !is_inf(d))
     {
         length = sprintf((char*)number_buffer, "null");
     }

--- a/cJSON.c
+++ b/cJSON.c
@@ -621,7 +621,7 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
     }
 
     /* This checks for NaN and Infinity */
-    if (is_nan(d) || !is_inf(d))
+    if (is_nan(d) || is_inf(d))
     {
         length = sprintf((char*)number_buffer, "null");
     }

--- a/smoketest.c
+++ b/smoketest.c
@@ -14,7 +14,7 @@ typedef void* DllLib;
 #define load_symbol(lib, name) dlsym(lib, name)
 #define SLASH "/"
 
-#elif defined(WIN32) 
+#elif defined(_WIN32) || defined(_WIN64)
 
 #include <windows.h>
 

--- a/tests.c
+++ b/tests.c
@@ -78,7 +78,7 @@ static const char *get_type_name[] = {
 	} \
 } while (0)
 
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
 #define SLASH "\\"
 #elif defined(__linux__)

--- a/tests.h
+++ b/tests.h
@@ -1,3 +1,4 @@
+#define _CRT_SECURE_NO_DEPRECATE
 #pragma once
 
 #define _XOPEN_SOURCE 700 // This is required to get struct FTW from ftw.h

--- a/tests.h
+++ b/tests.h
@@ -1,4 +1,3 @@
-#define _CRT_SECURE_NO_DEPRECATE
 #pragma once
 
 #define _XOPEN_SOURCE 700 // This is required to get struct FTW from ftw.h


### PR DESCRIPTION
Everything related to python is moved to it's own workflow that runs once per os instead of once per matrix combination

windows workflows are moved to their own workflow so they don't need to use MSYS to use the same script as the linux runners

added clang to windows CI.