### PR TITLE
fix: rename `arguments` to `parameters`

### DIFF
--- a/grug_grammar.py
+++ b/grug_grammar.py
@@ -60,7 +60,7 @@ class GrugTransformer(Transformer[Tree[Any], Any]):
             "statements": items[-1],
         }
         if items[2]:
-            func["arguments"] = items[2]
+            func["parameters"] = items[2]
         return func
 
     def helper_fn(self, items: List[Any]) -> Dict[str, Any]:
@@ -69,7 +69,7 @@ class GrugTransformer(Transformer[Tree[Any], Any]):
             "name": str(items[1]),
         }
         if items[2]:
-            func["arguments"] = items[2]
+            func["parameters"] = items[2]
         if items[3]:
             func["return_type"] = items[3]
         func["statements"] = items[-1]

--- a/tests/err_runtime/time_limit_exceeded_fibonacci/expected.json
+++ b/tests/err_runtime/time_limit_exceeded_fibonacci/expected.json
@@ -25,13 +25,13 @@
         "type": "GLOBAL_EMPTY_LINE"
     },
     {
-        "arguments": [
+        "name": "_fib",
+        "parameters": [
             {
                 "name": "n",
                 "type": "number"
             }
         ],
-        "name": "_fib",
         "return_type": "number",
         "statements": [
             {

--- a/tests/ok/f32_passed_to_helper_fn/expected.json
+++ b/tests/ok/f32_passed_to_helper_fn/expected.json
@@ -19,13 +19,13 @@
         "type": "GLOBAL_EMPTY_LINE"
     },
     {
-        "arguments": [
+        "name": "_foo",
+        "parameters": [
             {
                 "name": "f",
                 "type": "number"
             }
         ],
-        "name": "_foo",
         "statements": [
             {
                 "arguments": [

--- a/tests/ok/f32_passed_to_on_fn/expected.json
+++ b/tests/ok/f32_passed_to_on_fn/expected.json
@@ -1,12 +1,12 @@
 [
     {
-        "arguments": [
+        "name": "a",
+        "parameters": [
             {
                 "name": "f",
                 "type": "number"
             }
         ],
-        "name": "a",
         "statements": [
             {
                 "arguments": [

--- a/tests/ok/fibonacci/expected.json
+++ b/tests/ok/fibonacci/expected.json
@@ -25,13 +25,13 @@
         "type": "GLOBAL_EMPTY_LINE"
     },
     {
-        "arguments": [
+        "name": "_fib",
+        "parameters": [
             {
                 "name": "n",
                 "type": "number"
             }
         ],
-        "name": "_fib",
         "return_type": "number",
         "statements": [
             {

--- a/tests/ok/helper_fn_overwriting_param/expected.json
+++ b/tests/ok/helper_fn_overwriting_param/expected.json
@@ -23,7 +23,8 @@
         "type": "GLOBAL_EMPTY_LINE"
     },
     {
-        "arguments": [
+        "name": "_foo",
+        "parameters": [
             {
                 "name": "i",
                 "type": "number"
@@ -33,7 +34,6 @@
                 "type": "number"
             }
         ],
-        "name": "_foo",
         "statements": [
             {
                 "assignment": {

--- a/tests/ok/helper_fn_same_param_name_as_on_fn/expected.json
+++ b/tests/ok/helper_fn_same_param_name_as_on_fn/expected.json
@@ -1,12 +1,12 @@
 [
     {
-        "arguments": [
+        "name": "a",
+        "parameters": [
             {
                 "name": "x",
                 "type": "number"
             }
         ],
-        "name": "a",
         "statements": [
             {
                 "arguments": [
@@ -25,13 +25,13 @@
         "type": "GLOBAL_EMPTY_LINE"
     },
     {
-        "arguments": [
+        "name": "_foo",
+        "parameters": [
             {
                 "name": "x",
                 "type": "number"
             }
         ],
-        "name": "_foo",
         "statements": [
             {
                 "name": "nothing",

--- a/tests/ok/helper_fn_same_param_name_as_other_helper_fn/expected.json
+++ b/tests/ok/helper_fn_same_param_name_as_other_helper_fn/expected.json
@@ -1,12 +1,12 @@
 [
     {
-        "arguments": [
+        "name": "a",
+        "parameters": [
             {
                 "name": "x",
                 "type": "number"
             }
         ],
-        "name": "a",
         "statements": [
             {
                 "arguments": [
@@ -35,13 +35,13 @@
         "type": "GLOBAL_EMPTY_LINE"
     },
     {
-        "arguments": [
+        "name": "_foo",
+        "parameters": [
             {
                 "name": "x",
                 "type": "number"
             }
         ],
-        "name": "_foo",
         "statements": [
             {
                 "name": "nothing",
@@ -54,13 +54,13 @@
         "type": "GLOBAL_EMPTY_LINE"
     },
     {
-        "arguments": [
+        "name": "_bar",
+        "parameters": [
             {
                 "name": "x",
                 "type": "number"
             }
         ],
-        "name": "_bar",
         "statements": [
             {
                 "name": "nothing",

--- a/tests/ok/id_helper_fn_param/expected.json
+++ b/tests/ok/id_helper_fn_param/expected.json
@@ -19,13 +19,13 @@
         "type": "GLOBAL_EMPTY_LINE"
     },
     {
-        "arguments": [
+        "name": "_foo",
+        "parameters": [
             {
                 "name": "id",
                 "type": "id"
             }
         ],
-        "name": "_foo",
         "statements": [
             {
                 "arguments": [

--- a/tests/ok/id_on_fn_param/expected.json
+++ b/tests/ok/id_on_fn_param/expected.json
@@ -1,12 +1,12 @@
 [
     {
-        "arguments": [
+        "name": "a",
+        "parameters": [
             {
                 "name": "id",
                 "type": "id"
             }
         ],
-        "name": "a",
         "statements": [
             {
                 "arguments": [

--- a/tests/ok/me_passed_to_helper_fn/expected.json
+++ b/tests/ok/me_passed_to_helper_fn/expected.json
@@ -19,13 +19,13 @@
         "type": "GLOBAL_EMPTY_LINE"
     },
     {
-        "arguments": [
+        "name": "_foo",
+        "parameters": [
             {
                 "name": "foo",
                 "type": "D"
             }
         ],
-        "name": "_foo",
         "statements": [
             {
                 "arguments": [

--- a/tests/ok/on_fn_overwriting_param/expected.json
+++ b/tests/ok/on_fn_overwriting_param/expected.json
@@ -1,6 +1,7 @@
 [
     {
-        "arguments": [
+        "name": "a",
+        "parameters": [
             {
                 "name": "i",
                 "type": "number"
@@ -10,7 +11,6 @@
                 "type": "number"
             }
         ],
-        "name": "a",
         "statements": [
             {
                 "assignment": {

--- a/tests/ok/on_fn_passing_argument_to_helper_fn/expected.json
+++ b/tests/ok/on_fn_passing_argument_to_helper_fn/expected.json
@@ -19,13 +19,13 @@
         "type": "GLOBAL_EMPTY_LINE"
     },
     {
-        "arguments": [
+        "name": "_foo",
+        "parameters": [
             {
                 "name": "n",
                 "type": "number"
             }
         ],
-        "name": "_foo",
         "statements": [
             {
                 "arguments": [

--- a/tests/ok/pass_string_argument_to_helper_fn/expected.json
+++ b/tests/ok/pass_string_argument_to_helper_fn/expected.json
@@ -19,13 +19,13 @@
         "type": "GLOBAL_EMPTY_LINE"
     },
     {
-        "arguments": [
+        "name": "_shout",
+        "parameters": [
             {
                 "name": "message",
                 "type": "string"
             }
         ],
-        "name": "_shout",
         "statements": [
             {
                 "arguments": [

--- a/tests/ok/spill_args_to_helper_fn/expected.json
+++ b/tests/ok/spill_args_to_helper_fn/expected.json
@@ -91,7 +91,8 @@
         "type": "GLOBAL_EMPTY_LINE"
     },
     {
-        "arguments": [
+        "name": "_foo",
+        "parameters": [
             {
                 "name": "i1",
                 "type": "number"
@@ -157,7 +158,6 @@
                 "type": "number"
             }
         ],
-        "name": "_foo",
         "statements": [
             {
                 "arguments": [

--- a/tests/ok/spill_args_to_helper_fn_32_bit_f32/expected.json
+++ b/tests/ok/spill_args_to_helper_fn_32_bit_f32/expected.json
@@ -119,7 +119,8 @@
         "type": "GLOBAL_EMPTY_LINE"
     },
     {
-        "arguments": [
+        "name": "_foo",
+        "parameters": [
             {
                 "name": "s1",
                 "type": "string"
@@ -213,7 +214,6 @@
                 "type": "number"
             }
         ],
-        "name": "_foo",
         "statements": [
             {
                 "arguments": [

--- a/tests/ok/spill_args_to_helper_fn_32_bit_i32/expected.json
+++ b/tests/ok/spill_args_to_helper_fn_32_bit_i32/expected.json
@@ -167,7 +167,8 @@
         "type": "GLOBAL_EMPTY_LINE"
     },
     {
-        "arguments": [
+        "name": "_foo",
+        "parameters": [
             {
                 "name": "f1",
                 "type": "number"
@@ -309,7 +310,6 @@
                 "type": "number"
             }
         ],
-        "name": "_foo",
         "statements": [
             {
                 "arguments": [

--- a/tests/ok/spill_args_to_helper_fn_32_bit_string/expected.json
+++ b/tests/ok/spill_args_to_helper_fn_32_bit_string/expected.json
@@ -167,7 +167,8 @@
         "type": "GLOBAL_EMPTY_LINE"
     },
     {
-        "arguments": [
+        "name": "_foo",
+        "parameters": [
             {
                 "name": "f1",
                 "type": "number"
@@ -309,7 +310,6 @@
                 "type": "string"
             }
         ],
-        "name": "_foo",
         "statements": [
             {
                 "arguments": [

--- a/tests/ok/spill_args_to_helper_fn_subless/expected.json
+++ b/tests/ok/spill_args_to_helper_fn_subless/expected.json
@@ -95,7 +95,8 @@
         "type": "GLOBAL_EMPTY_LINE"
     },
     {
-        "arguments": [
+        "name": "_foo",
+        "parameters": [
             {
                 "name": "i1",
                 "type": "number"
@@ -165,7 +166,6 @@
                 "type": "number"
             }
         ],
-        "name": "_foo",
         "statements": [
             {
                 "arguments": [

--- a/tests/ok/string_can_be_passed_to_helper_fn/expected.json
+++ b/tests/ok/string_can_be_passed_to_helper_fn/expected.json
@@ -19,13 +19,13 @@
         "type": "GLOBAL_EMPTY_LINE"
     },
     {
-        "arguments": [
+        "name": "_foo",
+        "parameters": [
             {
                 "name": "s",
                 "type": "string"
             }
         ],
-        "name": "_foo",
         "statements": [
             {
                 "arguments": [


### PR DESCRIPTION
This affects export fns and local fns.